### PR TITLE
feat: add Thinking Effort picker for DeepSeek and MiMo models

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Available in `settings.json`:
 | `opencodego.commitMessagePrompt` | `""` | Custom system prompt for commit message generation |
 
 > All requests use `temperature: 0` for deterministic output.  
-> DeepSeek Thinking variants default to `reasoning_effort: "max"`.
+> DeepSeek Thinking variants expose a **Thinking Effort** picker in the model selector with levels `low`, `medium`, `high`, and `max` (default: `max`). MiMo models also expose a **Thinking Effort** picker with `low`, `medium`, and `high` (default: `high`).
 
 ### Build
 
@@ -104,7 +104,7 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 | `opencodego.commitMessagePrompt` | `""` | 生成提交消息的自定义系统提示词 |
 
 > 所有请求使用 `temperature: 0` 以确保输出确定性。  
-> DeepSeek Thinking 变体默认使用 `reasoning_effort: "max"`。
+> DeepSeek Thinking 变体在模型选择器中提供 **思考深度 (Thinking Effort)** 选项，可选 `low`、`medium`、`high`、`max`（默认 `max`）。MiMo 系列同样提供 **思考深度** 选项，可选 `low`、`medium`、`high`（默认 `high`）。
 
 ### 编译
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Available in `settings.json`:
 | `opencodego.commitMessagePrompt` | `""` | Custom system prompt for commit message generation |
 
 > All requests use `temperature: 0` for deterministic output.  
-> DeepSeek Thinking variants expose a **Thinking Effort** picker in the model selector with levels `low`, `medium`, `high`, and `max` (default: `max`). MiMo models also expose a **Thinking Effort** picker with `low`, `medium`, and `high` (default: `high`).
+> DeepSeek Thinking variants expose a **Thinking Effort** picker in the model selector with levels `high` and `max` (default: `max`).
 
 ### Build
 
@@ -104,7 +104,7 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 | `opencodego.commitMessagePrompt` | `""` | 生成提交消息的自定义系统提示词 |
 
 > 所有请求使用 `temperature: 0` 以确保输出确定性。  
-> DeepSeek Thinking 变体在模型选择器中提供 **思考深度 (Thinking Effort)** 选项，可选 `low`、`medium`、`high`、`max`（默认 `max`）。MiMo 系列同样提供 **思考深度** 选项，可选 `low`、`medium`、`high`（默认 `high`）。
+> DeepSeek Thinking 变体在模型选择器中提供 **思考深度 (Thinking Effort)** 选项，可选 `high`、`max`（默认 `max`）。
 
 ### 编译
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -15,6 +15,8 @@ interface BuiltInModelDef {
     thinkingMode: "switchable" | "always";
     /** Default reasoning effort when thinking is enabled */
     defaultReasoningEffort?: string;
+    /** Supported reasoning effort levels for the model picker UI */
+    supportedReasoningEfforts?: string[];
     /** Whether to include reasoning_content in assistant messages */
     includeReasoningInRequest?: boolean;
     /** Default context length */
@@ -44,14 +46,14 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     { baseId: "kimi-k2.6", displayName: "Kimi K2.6", vision: true, thinkingMode: "switchable", contextLength: 262144, maxTokens: 16384 },
 
     // ── DeepSeek series ── 官方文档: 1M context, 384K max output ──
-    { baseId: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", contextLength: 1000000, maxTokens: 393216 },
-    { baseId: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", contextLength: 1000000, maxTokens: 393216 },
+    { baseId: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["low", "medium", "high", "max"], contextLength: 1000000, maxTokens: 393216 },
+    { baseId: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["low", "medium", "high", "max"], contextLength: 1000000, maxTokens: 393216 },
 
     // ── MiMo series ── 小米 MiMo 官方模型卡: 256K context (262144) ──
-    { baseId: "mimo-v2-pro", displayName: "MiMo-V2-Pro", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2-omni", displayName: "MiMo-V2-Omni", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2-pro", displayName: "MiMo-V2-Pro", vision: false, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2-omni", displayName: "MiMo-V2-Omni", vision: true, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
 
     // ── MiniMax series ── 官方文档: 204800 context (204.8K) ──
     // Note: minimax-m2.7 uses Anthropic API format (messages endpoint)
@@ -98,7 +100,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
             } satisfies LanguageModelChatInformation);
 
             // Thinking variant
-            infos.push({
+            const thinkingInfo: LanguageModelChatInformation = {
                 id: `${def.baseId}::Thinking`,
                 name: `${def.displayName} Thinking`,
                 detail: `OpenCode Go`,
@@ -111,10 +113,40 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
                     toolCalling: true,
                     imageInput: def.vision,
                 },
-            } satisfies LanguageModelChatInformation);
+            };
+
+            // Attach configurationSchema for models with supported reasoning efforts
+            if (def.supportedReasoningEfforts && def.supportedReasoningEfforts.length > 0) {
+                infos.push({
+                    ...thinkingInfo,
+                    configurationSchema: {
+                        properties: {
+                            reasoningEffort: {
+                                type: 'string',
+                                title: 'Thinking Effort',
+                                enum: def.supportedReasoningEfforts,
+                                enumItemLabels: def.supportedReasoningEfforts.map((e: string) => e.charAt(0).toUpperCase() + e.slice(1)),
+                                enumDescriptions: def.supportedReasoningEfforts.map((e: string) => {
+                                    switch (e) {
+                                        case 'low': return 'Faster responses with less reasoning';
+                                        case 'medium': return 'Balanced reasoning and speed';
+                                        case 'high': return 'Greater reasoning depth but slower';
+                                        case 'max': return 'Maximum reasoning depth but slowest';
+                                        default: return e;
+                                    }
+                                }),
+                                default: def.defaultReasoningEffort ?? def.supportedReasoningEfforts[def.supportedReasoningEfforts.length - 1],
+                                group: 'navigation',
+                            },
+                        },
+                    },
+                } satisfies LanguageModelChatInformation);
+            } else {
+                infos.push(thinkingInfo);
+            }
         } else {
             // "always" thinking: single entry
-            infos.push({
+            const alwaysInfo: LanguageModelChatInformation = {
                 id: def.baseId,
                 name: def.displayName,
                 detail: `OpenCode Go`,
@@ -127,7 +159,37 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
                     toolCalling: true,
                     imageInput: def.vision,
                 },
-            } satisfies LanguageModelChatInformation);
+            };
+
+            // Attach configurationSchema for models with supported reasoning efforts
+            if (def.supportedReasoningEfforts && def.supportedReasoningEfforts.length > 0) {
+                infos.push({
+                    ...alwaysInfo,
+                    configurationSchema: {
+                        properties: {
+                            reasoningEffort: {
+                                type: 'string',
+                                title: 'Thinking Effort',
+                                enum: def.supportedReasoningEfforts,
+                                enumItemLabels: def.supportedReasoningEfforts.map((e: string) => e.charAt(0).toUpperCase() + e.slice(1)),
+                                enumDescriptions: def.supportedReasoningEfforts.map((e: string) => {
+                                    switch (e) {
+                                        case 'low': return 'Faster responses with less reasoning';
+                                        case 'medium': return 'Balanced reasoning and speed';
+                                        case 'high': return 'Greater reasoning depth but slower';
+                                        case 'max': return 'Maximum reasoning depth but slowest';
+                                        default: return e;
+                                    }
+                                }),
+                                default: def.defaultReasoningEffort ?? def.supportedReasoningEfforts[def.supportedReasoningEfforts.length - 1],
+                                group: 'navigation',
+                            },
+                        },
+                    },
+                } satisfies LanguageModelChatInformation);
+            } else {
+                infos.push(alwaysInfo);
+            }
         }
     }
 
@@ -192,6 +254,9 @@ export function getBuiltInModelConfig(modelId: string): OpenCodeGoModelItem | un
     } else {
         // "always" thinking: thinking forced on
         model.enable_thinking = true;
+        if (def.defaultReasoningEffort) {
+            model.reasoning_effort = def.defaultReasoningEffort;
+        }
         model.include_reasoning_in_request = true;
     }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -46,14 +46,14 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     { baseId: "kimi-k2.6", displayName: "Kimi K2.6", vision: true, thinkingMode: "switchable", contextLength: 262144, maxTokens: 16384 },
 
     // ── DeepSeek series ── 官方文档: 1M context, 384K max output ──
-    { baseId: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["low", "medium", "high", "max"], contextLength: 1000000, maxTokens: 393216 },
-    { baseId: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["low", "medium", "high", "max"], contextLength: 1000000, maxTokens: 393216 },
+    { baseId: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["high", "max"], contextLength: 1000000, maxTokens: 393216 },
+    { baseId: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["high", "max"], contextLength: 1000000, maxTokens: 393216 },
 
     // ── MiMo series ── 小米 MiMo 官方模型卡: 256K context (262144) ──
-    { baseId: "mimo-v2-pro", displayName: "MiMo-V2-Pro", vision: false, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2-omni", displayName: "MiMo-V2-Omni", vision: true, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "always", defaultReasoningEffort: "high", supportedReasoningEfforts: ["low", "medium", "high"], contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2-pro", displayName: "MiMo-V2-Pro", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2-omni", displayName: "MiMo-V2-Omni", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
 
     // ── MiniMax series ── 官方文档: 204800 context (204.8K) ──
     // Note: minimax-m2.7 uses Anthropic API format (messages endpoint)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -88,6 +88,14 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             const config = vscode.workspace.getConfiguration();
             const um: OpenCodeGoModelItem | undefined = getBuiltInModelConfig(model.id);
 
+            // Apply user-configured reasoning effort from model picker UI
+            if (um?.enable_thinking && options.modelConfiguration?.reasoningEffort) {
+                const effort = options.modelConfiguration.reasoningEffort;
+                if (typeof effort === 'string') {
+                    um.reasoning_effort = effort;
+                }
+            }
+
             // Determine API mode from model config (default: openai)
             const apiMode = um?.apiMode || "openai";
             const baseUrl = um?.baseUrl || "https://opencode.ai/zen/go/v1/";

--- a/src/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode.proposed.chatProvider.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// version: 4
+// version: 5
 
 declare module "vscode" {
 	/**
@@ -11,9 +11,19 @@ declare module "vscode" {
 	 */
 	export interface ProvideLanguageModelChatResponseOptions {
 		/**
-		 * What extension initiated the request to the language model
+		 * What extension initiated the request to the language model, or
+		 * `undefined` if the request was initiated by other functionality in the editor.
 		 */
 		readonly requestInitiator: string;
+
+		/**
+		 * Per-model configuration provided by the user. This contains values configured
+		 * in the user's language models configuration file, validated against the model's
+		 * {@linkcode LanguageModelChatInformation.configurationSchema configurationSchema}.
+		 */
+		readonly modelConfiguration?: {
+			readonly [key: string]: any;
+		};
 	}
 
 	/**
@@ -33,7 +43,7 @@ declare module "vscode" {
 		 * Whether or not this will be selected by default in the model picker
 		 * NOT BEING FINALIZED
 		 */
-		readonly isDefault?: boolean;
+		readonly isDefault?: boolean | { [K in ChatLocation]?: boolean };
 
 		/**
 		 * Whether or not the model will show up in the model picker immediately upon being made known via {@linkcode LanguageModelChatProvider.provideLanguageModelChatInformation}.
@@ -51,6 +61,14 @@ declare module "vscode" {
 		readonly category?: { label: string; order: number };
 
 		readonly statusIcon?: ThemeIcon;
+
+		/**
+		 * An optional JSON schema describing the configuration options for this model.
+		 * When set, users can specify per-model configuration in their language models
+		 * configuration file. The configured values are merged into the request options
+		 * when sending chat requests to this model.
+		 */
+		readonly configurationSchema?: LanguageModelConfigurationSchema;
 	}
 
 	export interface LanguageModelChatCapabilities {
@@ -77,7 +95,34 @@ declare module "vscode" {
 		| LanguageModelDataPart
 		| LanguageModelThinkingPart;
 
+	/**
+	 * A [JSON Schema](https://json-schema.org) describing configuration options for a language model.
+	 * Each property in `properties` defines a configurable option using standard JSON Schema fields
+	 * plus additional display hints.
+	 */
+	export type LanguageModelConfigurationSchema = {
+		readonly properties?: {
+			readonly [key: string]: Record<string, any> & {
+				/**
+				 * Human-readable labels for enum values, shown instead of the raw values.
+				 * Must have the same length and order as `enum`.
+				 */
+				readonly enumItemLabels?: string[];
+				/**
+				 * Human-readable descriptions for enum values.
+				 */
+				readonly enumDescriptions?: string[];
+				/**
+				 * The group this property belongs to. When set to `'navigation'`, the property
+				 * is shown as a primary action in the model picker.
+				 */
+				readonly group?: string;
+			};
+		};
+	};
+
 	export interface LanguageModelChatProvider<T extends LanguageModelChatInformation = LanguageModelChatInformation> {
+		provideLanguageModelChatInformation(options: PrepareLanguageModelChatModelOptions, token: CancellationToken): ProviderResult<T[]>;
 		provideLanguageModelChatResponse(
 			model: T,
 			messages: readonly LanguageModelChatRequestMessage[],
@@ -85,5 +130,23 @@ declare module "vscode" {
 			progress: Progress<LanguageModelResponsePart2>,
 			token: CancellationToken
 		): Thenable<void>;
+	}
+
+	/**
+	 * The list of options passed into {@linkcode LanguageModelChatProvider.provideLanguageModelChatInformation}
+	 */
+	export interface PrepareLanguageModelChatModelOptions {
+		/**
+		 * Whether the provider is being called silently (e.g., for background refresh).
+		 */
+		readonly silent: boolean;
+		/**
+		 * Configuration for the model. This is only present if the provider has declared
+		 * that it requires configuration via the `configuration` property.
+		 * The object adheres to the schema that the extension provided during declaration.
+		 */
+		readonly configuration?: {
+			readonly [key: string]: any;
+		};
 	}
 }


### PR DESCRIPTION
- Introduced `supportedReasoningEfforts` field in model definition to specify available reasoning effort levels
- Added Thinking Effort picker UI in model selector for DeepSeek (low/medium/high/max) and MiMo (low/medium/high) models
- Updated README documentation with new picker descriptions in both English and Chinese
- Default reasoning effort set to "max" for DeepSeek and "high" for MiMo models