### PR TITLE
fix: models missing from model picker in VS Code 1.120

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,5 @@
 # OpenCode Go Copilot Provider — AGENTS.md
 
-> **版本**: 0.4.2 | **最后更新**: 2026-05-05  
 > **所有更改必须通过 `npm run compile` / `npx tsc --noEmit` 编译检查无错误通过。**  
 > **每次更改后，必须同步更新本文档 (`AGENTS.md`) 以反映代码变更。**
 
@@ -335,7 +334,7 @@ src/
 创建 undici fetch 实例，设置自定义 `bodyTimeout` 防止流式响应中 TCP 空闲连接被提前关闭。回退到全局 `fetch`。
 
 #### `provideLanguageModelChatInformation(options, _token): Promise<LanguageModelChatInformation[]>`
-获取可用的语言模型列表。委托给 `prepareLanguageModelChatInformation()`。
+获取可用的语言模型列表。参数类型为 `PrepareLanguageModelChatModelOptions`，委托给 `prepareLanguageModelChatInformation()`。
 
 #### `provideTokenCount(_model, text, _token): Promise<number>`
 计算文本或消息的 Token 数量。委托给 `countMessageTokens()`。
@@ -371,7 +370,7 @@ src/
 14 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
-将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/思考` 或 `禁用思考/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
+将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/思考` 或 `禁用思考/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
 
 #### `getBuiltInModelCount(): number`
 返回内置模型定义总数（BUILT_IN_MODELS.length）。

--- a/README.md
+++ b/README.md
@@ -52,7 +52,22 @@ Available in `settings.json`:
 | `opencodego.recentCommitsCount` | `10` | Number of recent commits to analyze for style reference when generating commit messages. Set to 0 to disable. |
 
 > All requests use `temperature: 0` for deterministic output.  
-> Models with switchable thinking provide Disabled/Thinking or Disabled/High/Maximum options in the Reasoning Effort panel (e.g., DeepSeek).
+> Models with switchable thinking (e.g., DeepSeek, Qwen) provide reasoning effort levels such as Disabled/High/Maximum.
+
+> **VS Code 1.120+**: To configure thinking effort for a model:
+> 1. Click the model name in the Chat model picker to open the dropdown
+> 2. Click the **gear icon** ⚙️ to the right of the model name
+> 3. Select the desired **Thinking Effort** level
+>
+> The current effort level is shown next to the model name in the picker button (e.g., "DeepSeek V4 Pro · High"). Directly clicking the label text is not supported — use the gear icon submenu instead.
+>
+> You can also set a permanent default via VS Code's language model configuration file (`.vscode/languageModelConfiguration.json`):
+> ```json
+> {
+>   "opencodego.deepseek-v4-pro.reasoningEffort": "max",
+>   "opencodego.deepseek-v4-flash.reasoningEffort": "disabled"
+> }
+> ```
 
 ### Build
 
@@ -116,7 +131,22 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 | `opencodego.recentCommitsCount` | `10` | 生成提交消息时参考的近期提交数量，用于学习仓库提交风格。设为 0 可禁用。 |
 
 > 所有请求使用 `temperature: 0` 以确保输出确定性。  
-> 支持切换思考模式的模型在推理强度面板中提供`禁用思考`/`思考`或`禁用思考`/`高`/`极高`选项（如 DeepSeek）。
+> 支持切换思考模式的模型（如 DeepSeek、Qwen）提供`禁用思考`/`高`/`极高`等推理强度选项。
+
+> **VS Code 1.120+**: 如需修改模型的推理强度：
+> 1. 点击 Chat 底部模型选择器中的模型名称，打开下拉菜单
+> 2. 点击模型名称右侧的**齿轮图标** ⚙️
+> 3. 选择需要的**推理强度**级别
+>
+> 当前强度级别会显示在模型选择器按钮中（如 "DeepSeek V4 Pro · 极高"），但该文本仅为标签，无法直接点击修改，请使用齿轮图标子菜单。
+>
+> 也可以通过 VS Code 的语言模型配置文件（`.vscode/languageModelConfiguration.json`）设置永久默认值：
+> ```json
+> {
+>   "opencodego.deepseek-v4-pro.reasoningEffort": "max",
+>   "opencodego.deepseek-v4-flash.reasoningEffort": "disabled"
+> }
+> ```
 
 ### 编译
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -91,6 +91,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
             version: "1.0.0",
             maxInputTokens: maxInput,
             maxOutputTokens: 0,
+            isUserSelectable: true,
             capabilities: {
                 toolCalling: true,
                 imageInput: def.vision,

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { CancellationToken, LanguageModelChatInformation } from "vscode";
+import { CancellationToken, LanguageModelChatInformation, PrepareLanguageModelChatModelOptions } from "vscode";
 
 import { logger } from "./logger";
 import { getBuiltInModelInfos } from "./models";
@@ -10,7 +10,7 @@ const EXTENSION_LABEL = "OpenCodeGo";
  * Get the list of available language models contributed by this provider.
  */
 export async function prepareLanguageModelChatInformation(
-    options: { silent: boolean },
+    options: PrepareLanguageModelChatModelOptions,
     _token: CancellationToken,
     _secrets: vscode.SecretStorage
 ): Promise<LanguageModelChatInformation[]> {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,6 +4,7 @@ import {
     LanguageModelChatInformation,
     LanguageModelChatProvider,
     LanguageModelChatRequestMessage,
+    PrepareLanguageModelChatModelOptions,
     ProvideLanguageModelChatResponseOptions,
     LanguageModelResponsePart2,
     Progress,
@@ -63,10 +64,10 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
      * Get the list of available language models contributed by this provider.
      */
     async provideLanguageModelChatInformation(
-        options: { silent: boolean },
+        options: PrepareLanguageModelChatModelOptions,
         _token: CancellationToken
     ): Promise<LanguageModelChatInformation[]> {
-        return prepareLanguageModelChatInformation({ silent: options.silent ?? false }, _token, this.secrets);
+        return prepareLanguageModelChatInformation(options, _token, this.secrets);
     }
 
     /**

--- a/src/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode.proposed.chatProvider.d.ts
@@ -63,6 +63,15 @@ declare module "vscode" {
 		readonly statusIcon?: ThemeIcon;
 
 		/**
+		 * When set, this model is only shown in the model picker for the specified
+		 * chat session type. Models with this property are excluded from the general
+		 * model picker and only appear when the user is in a session matching this type.
+		 *
+		 * The value must match a `type` declared in a `chatSessions` extension contribution.
+		 */
+		readonly targetChatSessionType?: string;
+
+		/**
 		 * An optional JSON schema describing the configuration options for this model.
 		 * When set, users can specify per-model configuration in their language models
 		 * configuration file. The configured values are merged into the request options
@@ -136,10 +145,6 @@ declare module "vscode" {
 	 * The list of options passed into {@linkcode LanguageModelChatProvider.provideLanguageModelChatInformation}
 	 */
 	export interface PrepareLanguageModelChatModelOptions {
-		/**
-		 * Whether the provider is being called silently (e.g., for background refresh).
-		 */
-		readonly silent: boolean;
 		/**
 		 * Configuration for the model. This is only present if the provider has declared
 		 * that it requires configuration via the `configuration` property.


### PR DESCRIPTION
VS Code 1.120 enforces the `isUserSelectable` property on `LanguageModelChatInformation` — models without `isUserSelectable: true` are filtered out of the model picker.

Changes:
- Add `isUserSelectable: true` to all built-in model entries in `getBuiltInModelInfos()` (src/models.ts)
- Sync proposed API types with VS Code 1.120:
  - Add `targetChatSessionType` field to `LanguageModelChatInformation`
  - Remove deprecated `silent` property from `PrepareLanguageModelChatModelOptions`
- Update `provideLanguageModelChatInformation()` signature in provider.ts and provideModel.ts to use `PrepareLanguageModelChatModelOptions`
- Update AGENTS.md to reflect changes

Close #8 