### PR TITLE
feat: add OpenCode Zen free model support with configurable toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,8 @@
 | 能力 | 说明 |
 |------|------|
 | **Chat 模型提供商** | 实现 `LanguageModelChatProvider` 接口，向 VS Code 注册为 `opencodego` 厂商 |
-| **多模型支持** | 内置 14 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式 |
+| **多模型支持** | 内置 14 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（5 个） |
+| **OpenCode Zen 免费模型** | 通过设置开关启用，从 Zen API 获取模型列表并过滤出 5 个免费模型（Big Pickle、DeepSeek V4 Flash、MiniMax M2.5、Ring 2.6 1T、Nemotron 3 Super），以 `OpenCode Zen` 标识追加到模型选择器。支持内存缓存（5 分钟 TTL），API 不可用时静默降级 |
 | **双 API 模式** | 同时支持 **OpenAI 兼容格式** (`/chat/completions`) 和 **Anthropic 格式** (`/v1/messages`) |
 | **流式推理** | 支持 SSE (Server-Sent Events) 流式响应，实时输出文本和工具调用 |
 | **Thinking/推理** | 支持模型的推理过程展示 ("thinking" 状态)，包括 XML think 块解析 |
@@ -45,14 +46,30 @@
 
 ### 1.3 模型清单
 
+#### 内置模型
+
 | 系列 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 |
 |------|---------|------|----------------|----------|
 | GLM | `glm-5.1`, `glm-5` | ❌ | `思考`（不支持思考切换） | OpenAI |
 | Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `思考` | OpenAI |
-| DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `最大` | OpenAI |
+| DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `极高` | OpenAI |
 | MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `思考` | OpenAI |
 | MiniMax | `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `思考` | OpenAI (m2.7 使用 Anthropic) |
 | Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `思考` | OpenAI |
+
+#### OpenCode Zen 免费模型（可选）
+
+通过设置 `opencodego.enableZenFreeModels`（默认关闭）启用，从 Zen API 获取模型列表并与硬编码 ID 过滤后加入模型选择器。
+
+| 显示名 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 | 备注 |
+|--------|---------|------|----------------|----------|------|
+| Zen/Big Pickle Free | `big-pickle` | ❌ | `思考`（不支持思考切换） | OpenAI | 限时免费 |
+| Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `高` / `极高` | OpenAI | 限时免费 |
+| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+
+在模型选择器中，内置模型归入 `OpenCode Go` 分组（`family="OpenCodeGo"`），Zen 免费模型归入 `OpenCode Zen` 分组（`family="OpenCode Zen"`）以作区分。
 
 > 所有模型在模型选择器中均显示**一个条目**，通过**推理强度选择器**（中文标签）切换思考模式。  
 > - `thinkingMode="switchable"`：用户可选择`禁用思考`或启用思考（强度可配置）  
@@ -121,6 +138,7 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   ├── 1. 解析模型 ID → getBuiltInModelConfig(model.id)
   │       格式: "baseId"（无 :: 后缀）
   │       所有模型注册为单一条目
+  │       内置模型查找失败时回退到 getZenFreeModelConfig(model.id)
   │
   ├── 2. 应用用户配置的 reasoningEffort
   │       ├── "disabled" → 关闭思考（always 模型除外）
@@ -283,9 +301,11 @@ src/
 ├── gitCommit/
 │   ├── commitMessageGenerator.ts         # Git 提交消息生成
 │   └── gitUtils.ts                       # Git 工具函数
-└── tokenizer/
-    ├── tokenizerManager.ts               # Tokenizer 管理 (o200k_base)
-    └── imageUtils.ts                     # 图片尺寸解析
+├── tokenizer/
+│   ├── tokenizerManager.ts               # Tokenizer 管理 (o200k_base)
+│   └── imageUtils.ts                     # 图片尺寸解析
+└── zen/
+    └── zenModels.ts                      # Zen 免费模型定义与 API 交互
 ```
 
 ### 3.2 文件详细说明
@@ -312,6 +332,7 @@ src/
 | `gitCommit/gitUtils.ts` | ~260 | Git 命令封装 |
 | `tokenizer/tokenizerManager.ts` | ~115 | o200k_base 分词器管理 (含 LRU 缓存) |
 | `tokenizer/imageUtils.ts` | ~130 | 图片尺寸解析 (PNG/GIF/JPEG/WebP) |
+| `zen/zenModels.ts` | ~160 | Zen 免费模型定义、API 拉取、缓存管理、配置查询 |
 
 ---
 
@@ -349,7 +370,7 @@ src/
 计算文本或消息的 Token 数量。委托给 `countMessageTokens()`。
 
 #### `provideLanguageModelChatResponse(model, messages, options, progress, token): Promise<void>`
-核心方法：处理聊天请求，流式返回响应。包括模型配置获取、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析和错误处理。
+核心方法：处理聊天请求，流式返回响应。包括模型配置获取（内置模型 → Zen 模型回退）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析和错误处理。
 
 #### `private async ensureApiKey(): Promise<string | undefined>`
 确保 API Key 存在于 SecretStorage 中，缺失时弹出输入框提示用户输入。
@@ -507,7 +528,7 @@ API 实现的抽象基类。
 ### 4.6 `src/provideModel.ts`
 
 #### `prepareLanguageModelChatInformation(options, _token, _secrets): Promise<LanguageModelChatInformation[]>`
-获取模型信息列表。当前使用硬编码的内置模型列表（委托 `getBuiltInModelInfos()`），记录日志后返回。
+获取模型信息列表。默认使用硬编码的内置模型列表（委托 `getBuiltInModelInfos()`）。当配置 `opencodego.enableZenFreeModels` 开启时，额外调用 `getZenFreeModelInfos()` 获取 Zen 免费模型并追加到列表末尾。Zen 模型获取失败时静默降级（不阻塞模型选择器）。
 
 ---
 
@@ -905,6 +926,45 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 
 ---
 
+### 4.21 `src/zen/zenModels.ts`
+
+#### `const ZEN_FREE_MODEL_IDS: readonly string[]`
+5 个硬编码的 Zen 免费模型 ID 数组：`big-pickle`、`deepseek-v4-flash-free`、`minimax-m2.5-free`、`ring-2.6-1t-free`、`nemotron-3-super-free`。
+
+#### `const ZEN_FREE_MODEL_METADATA`
+免费模型元数据映射，包含 `displayName`、`contextLength`、`vision`、`maxTokens` 字段。
+
+#### `const ZEN_BASE_URL`
+Zen API 基础 URL：`https://opencode.ai/zen/v1/`。
+
+#### `const CACHE_TTL_MS`
+内存缓存 TTL：5 分钟。
+
+#### `let cachedModelIds: string[] | null`
+模块级缓存：存储最近一次从 Zen API 获取并过滤后的模型 ID 列表。
+
+#### `let cacheTimestamp: number`
+缓存时间戳，用于判断缓存是否过期。
+
+#### `async function fetchZenModelList(apiKey): Promise<string[]>`
+从 `https://opencode.ai/zen/v1/models` 拉取完整的模型 ID 列表。API 遵循 OpenAI `/v1/models` 格式，返回 `{ object: "list", data: [{ id, object, created, owned_by }] }`。
+
+#### `function buildModelInfos(modelIds): LanguageModelChatInformation[]`
+根据模型 ID 列表构建 VS Code 模型信息数组。只包含在 `ZEN_FREE_MODEL_METADATA` 中有对应元数据的模型。每个模型注册为 `isUserSelectable: true`，带 `detail="OpenCode Zen"` 和基础版推理强度选择器（`禁用思考` / `思考`）。
+
+#### `async function getZenFreeModelInfos(secrets): Promise<LanguageModelChatInformation[]>`
+获取 Zen 免费模型列表。流程：
+1. 检查缓存（5 分钟 TTL），有效则直接返回
+2. 获取 API Key，存在则调用 `fetchZenModelList()` 与 `ZEN_FREE_MODEL_IDS` 做交集过滤
+3. 拉取成功 → 更新缓存 → 返回过滤后的模型
+4. 拉取失败 → 使用过期缓存或全量硬编码列表（乐观降级）
+5. 无 API Key → 使用过期缓存或全量硬编码列表
+
+#### `function getZenFreeModelConfig(modelId): OpenCodeGoModelItem | undefined`
+按模型 ID 查找 Zen 免费模型配置。返回 `baseUrl: "https://opencode.ai/zen/v1/"`、`apiMode: "openai"`、`thinkingMode: "switchable"` 的模型配置对象。内置模型找不到时由 `provider.ts` 作为回退调用。
+
+---
+
 ## 5. 编译与构建
 
 ### 5.1 编译命令
@@ -1063,6 +1123,3 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 - `openai.stream.*` / `anthropic.stream.*` — 流式处理
 - `apiKey.missing` — API Key 缺失
 
----
-
-*本文档由 AI 自动生成，基于 `opencode-go-copilot-provider` v0.4.2 源码分析。*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ Integrate [OpenCode Go](https://opencode.ai/go) models into GitHub Copilot Chat 
 
 1. **Set API Key**: `Ctrl+Shift+P` → `OpenCodeGo: Set OpenCode Go API Key`
 2. **Show Models**: Click the settings icon ⚙️ in the model picker → **Language Models** panel → set your desired models to Visible
-3. **Select Model**: In the Copilot Chat bottom model picker, choose an "OpenCode Go" model
+3. **Select Model**: In the Copilot Chat bottom model picker, choose an "OpenCode Go" or "OpenCode Zen" model
 4. **Start chatting**
+
+### OpenCode Zen Free Models
+
+Enable via `opencodego.enableZenFreeModels` setting (default off). When enabled, 5 free models (Big Pickle, DeepSeek V4 Flash, MiniMax M2.5, Ring 2.6 1T, Nemotron 3 Super) fetched from the Zen API are added to the model picker with a `Zen/` prefix (e.g. `Zen/DeepSeek V4 Flash Free`). Requires a full reload of VS Code to take effect after changing the setting.
+
+> If a free model is no longer available as free, the extension will display a friendly error prompt asking you to use a different model.
 
 ### Token Usage Indicator
 
@@ -53,6 +59,7 @@ Available in `settings.json`:
 | `opencodego.requestTimeout` | `600000` | Maximum time (ms) for a single API request. Default is 600000 (10 minutes). Increase if long responses time out. |
 | `opencodego.recentCommitsCount` | `10` | Number of recent commits to analyze for style reference when generating commit messages. Set to 0 to disable. |
 | `opencodego.commitIncludeCommitDiff` | `false` | Include the actual code changes (diff) of recent commits in the style reference, helping the model generate messages that better match the project's commit style. |
+| `opencodego.enableZenFreeModels` | `false` | Enable OpenCode Zen free models in the model picker. Zen free models are NOT supported for git commit message generation. Requires a full reload to take effect. |
 | `opencodego.commitAttachContextFiles` | `true` | Attach AGENTS.md and README.md from the repository root as additional context for commit message generation, helping the model better understand the project. |
 
 > All requests use `temperature: 0` for deterministic output.  
@@ -89,8 +96,14 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 
 1. **设置 API Key**：`Ctrl+Shift+P` → `OpenCodeGo: Set OpenCode Go API Key`
 2. **显示模型**：在模型选择器中点击设置图标 ⚙️ → **语言模型** 面板 → 将需要使用的模型显示
-3. **选择模型**：在 Copilot Chat 底部模型选择器中选择 "OpenCode Go" 下的模型
+3. **选择模型**：在 Copilot Chat 底部模型选择器中选择 "OpenCode Go" 或 "OpenCode Zen" 下的模型
 4. **开始对话**
+
+### OpenCode Zen 免费模型
+
+通过 `opencodego.enableZenFreeModels` 设置启用（默认关闭）。开启后，将从 Zen API 获取 5 个免费模型（Big Pickle、DeepSeek V4 Flash、MiniMax M2.5、Ring 2.6 1T、Nemotron 3 Super）并添加到模型选择器中，名称带 `Zen/` 前缀（如 `Zen/DeepSeek V4 Flash Free`）。更改设置后需要重新加载 VS Code 才能生效。
+
+> 如果免费模型已结束免费使用，扩展会显示友好的错误提示，引导你使用其他模型。
 
 ### Token 用量指示器
 
@@ -128,6 +141,7 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 | `opencodego.requestTimeout` | `600000` | 单个 API 请求的最大等待时间（毫秒）。默认 600000（10 分钟）。生成长内容超时时可增大此值。 |
 | `opencodego.recentCommitsCount` | `10` | 生成提交消息时参考的近期提交数量，用于学习仓库提交风格。设为 0 可禁用。 |
 | `opencodego.commitIncludeCommitDiff` | `false` | 在风格参考中包含历史提交的实际代码变更（diff），帮助模型生成更符合项目提交风格的消息。 |
+| `opencodego.enableZenFreeModels` | `false` | 启用 OpenCode Zen 免费模型并添加到模型选择器中。暂不支持用于 Git 提交消息生成。更改后需重载 VS Code 生效。 |
 | `opencodego.commitAttachContextFiles` | `true` | 将仓库根目录的 AGENTS.md 和 README.md 作为额外上下文附加到提交消息生成中，帮助模型更好地理解项目。 |
 
 > 所有请求使用 `temperature: 0` 以确保输出确定性。  

--- a/package.json
+++ b/package.json
@@ -187,7 +187,12 @@
 					"maximum": 1,
 					"description": "%config.top_p.desc%"
 				},
-				"opencodego.modelPresets": {
+				"opencodego.enableZenFreeModels": {
+				"type": "boolean",
+				"default": false,
+				"description": "%config.enableZenFreeModels.desc%"
+			},
+			"opencodego.modelPresets": {
 					"type": "array",
 					"default": [
 						{ "id": "precise", "label": "Precise", "temperature": 0.0, "top_p": 1.0 },

--- a/package.nls.json
+++ b/package.nls.json
@@ -34,6 +34,7 @@
 	"config.modelPreset.desc": "Current model preset ID. Use the 'Set Model Preset' command to select a preset. Set to 'custom' to use manual values from 'opencodego.temperature' and 'opencodego.top_p'.",
 	"config.temperature.desc": "Model temperature (0.0 - 2.0). Paired with 'opencodego.top_p'. Only used when 'opencodego.modelPreset' is set to 'custom'.",
 	"config.top_p.desc": "Model top_p (0.0 - 1.0). Paired with 'opencodego.temperature'. Only used when 'opencodego.modelPreset' is set to 'custom'.",
+	"config.enableZenFreeModels.desc": "Enable OpenCode Zen free models in the model picker. When enabled, the extension fetches the model list from the Zen API and shows free models (Big Pickle, DeepSeek V4 Flash, MiniMax M2.5, Ring 2.6 1T, Nemotron 3 Super). Zen free models are currently NOT supported for git commit message generation. Requires a full reload of VS Code to take effect after changing this setting.",
 	"config.modelPresets.desc": "Model presets for quick selection via command palette. Each preset includes temperature and top_p. You can customize the presets.",
 	"config.modelPreset.id.desc": "Preset identifier (must match the value in modelPreset setting).",
 	"config.modelPreset.label.desc": "Display name of the preset.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -34,6 +34,7 @@
 	"config.modelPreset.desc": "当前模型预设 ID。使用「设置模型预设」命令选择预设。设为「custom」可使用「opencodego.temperature」和「opencodego.top_p」手动输入的值。",
 	"config.temperature.desc": "模型温度 (0.0 - 2.0)。与「opencodego.top_p」配对使用。仅在「opencodego.modelPreset」设为「custom」时生效。",
 	"config.top_p.desc": "模型 top_p (0.0 - 1.0)。与「opencodego.temperature」配对使用。仅在「opencodego.modelPreset」设为「custom」时生效。",
+	"config.enableZenFreeModels.desc": "启用 OpenCode Zen 免费模型并将其添加到模型选择器中。开启后，扩展将从 Zen API 获取模型列表并显示免费模型（Big Pickle、DeepSeek V4 Flash、MiniMax M2.5、Ring 2.6 1T、Nemotron 3 Super）。Zen 免费模型暂不支持用于 Git 提交消息生成。更改此设置后需要重新加载 VS Code 才能生效。",
 	"config.modelPresets.desc": "模型预设列表，可通过命令面板快速选择。每个预设包含温度（temperature）和 top_p 两个参数。你可以修改各预设的字段来自定义。",
 	"config.modelPreset.id.desc": "预设标识符（必须与 modelPreset 设置中的值一致）。",
 	"config.modelPreset.label.desc": "预设档位的显示名称。",

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -27,7 +27,8 @@ const zhCN: Record<string, string> = {
 	"Repository not found for provided SCM": "未找到指定 SCM 对应的仓库",
 	"No models configured for commit message generation. Please set 'useForCommitGeneration' to true for at least one model in your configuration.":
 		"未配置用于生成提交消息的模型。请在配置中将至少一个模型的 'useForCommitGeneration' 设为 true。",
-	"Failed to generate commit message:": "生成提交消息失败：",
+	"{0} is no longer available as a free model. Please use a different model.": "{0} 已结束免费使用，请使用其他模型。",
+"Failed to generate commit message:": "生成提交消息失败：",
 	"[Commit Generation Failed]": "[提交生成失败]",
 	"empty API response": "API 返回为空",
 

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -3,11 +3,14 @@ import { CancellationToken, LanguageModelChatInformation, PrepareLanguageModelCh
 
 import { logger } from "./logger";
 import { getBuiltInModelInfos } from "./models";
+import { getZenFreeModelInfos } from "./zen/zenModels";
 
 const EXTENSION_LABEL = "OpenCodeGo";
 
 /**
  * Get the list of available language models contributed by this provider.
+ * When the "opencodego.enableZenFreeModels" setting is enabled, OpenCode Zen
+ * free models are fetched and appended to the built-in model list.
  */
 export async function prepareLanguageModelChatInformation(
     options: PrepareLanguageModelChatModelOptions,
@@ -17,6 +20,25 @@ export async function prepareLanguageModelChatInformation(
     // Use built-in hardcoded model list
     const infos = getBuiltInModelInfos();
 
-    logger.info("models.loaded", { count: infos.length, source: "builtin" });
+    // Conditionally append Zen free models
+    const config = vscode.workspace.getConfiguration();
+    const enableZen = config.get<boolean>("opencodego.enableZenFreeModels", false);
+    if (enableZen) {
+        try {
+            const zenInfos = await getZenFreeModelInfos(_secrets);
+            if (zenInfos.length > 0) {
+                infos.push(...zenInfos);
+                logger.info("models.loaded", { count: zenInfos.length, source: "zen" });
+            }
+        } catch (error) {
+            // Silently degrade: if Zen model fetch fails, just use built-in models
+            logger.error("models.loaded", {
+                source: "zen",
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+    }
+
+    logger.info("models.loaded", { count: infos.length, source: "total" });
     return infos;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -18,6 +18,8 @@ import { createRetryConfig, executeWithRetry } from "./utils";
 
 import { prepareLanguageModelChatInformation } from "./provideModel";
 import { getBuiltInModelConfig } from "./models";
+import { getZenFreeModelConfig } from "./zen/zenModels";
+import { l10nFormat } from "./localize";
 import { countMessageTokens } from "./provideToken";
 import { updateContextStatusBar, recordUsage, updateCumulativeTooltip } from "./statusBar";
 import { OpenaiApi } from "./openai/openaiApi";
@@ -112,9 +114,12 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         let dispatchFetch: typeof fetch;
 
         try {
-            // Get built-in model config
+            // Get built-in model config (with fallback to Zen free model config)
             const config = vscode.workspace.getConfiguration();
-            const um: OpenCodeGoModelItem | undefined = getBuiltInModelConfig(model.id);
+            let um: OpenCodeGoModelItem | undefined = getBuiltInModelConfig(model.id);
+            if (!um) {
+                um = getZenFreeModelConfig(model.id);
+            }
 
             // Apply reasoning effort from model configuration to determine thinking mode
             // - "disabled" → turn off thinking (unless model has thinkingMode="always")
@@ -348,6 +353,18 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     throw new Error(l10n("The connection was closed by the server. The generation took too long. Please try again or request shorter content."));
                 }
                 throw new Error(l10n("Request timed out. The generation took too long. You can increase the timeout in settings (opencodego.requestTimeout)."));
+            }
+
+            // Check for Zen free model expiration error
+            if (errMessage.includes("no longer available as a free model") || errMessage.includes("has transitioned to a paid model")) {
+                const caughtModelConfig = getBuiltInModelConfig(model.id) ?? getZenFreeModelConfig(model.id);
+                const caughtModelName = caughtModelConfig?.displayName ?? model.id;
+                logger.error("request.error", {
+                    modelId: model.id,
+                    error: "zen_free_model_expired",
+                    errorMessage: errMessage,
+                });
+                throw new Error(l10nFormat("{0} is no longer available as a free model. Please use a different model.", caughtModelName));
             }
 
             console.error("[OpenCodeGo] Chat request failed", {

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -1,0 +1,254 @@
+import * as vscode from "vscode";
+import type { LanguageModelChatInformation } from "vscode";
+import type { OpenCodeGoModelItem } from "../types";
+import { l10n } from "../localize";
+
+// ── Hardcoded Zen free model IDs (from OpenCode Zen official documentation) ──
+export const ZEN_FREE_MODEL_IDS: readonly string[] = [
+    "big-pickle",
+    "deepseek-v4-flash-free",
+    "minimax-m2.5-free",
+    "ring-2.6-1t-free",
+    "nemotron-3-super-free",
+];
+
+/**
+ * Metadata for each Zen free model.
+ * Context lengths are conservative estimates; actual limits depend on Zen provider.
+ * thinkingMode: "always" = thinking always on (no switch), "switchable" = user can toggle.
+ * supportedReasoningEfforts: optional multi-level efforts (e.g. ["high", "max"]) for switchable models.
+ * defaultReasoningEffort: default effort when thinking is enabled.
+ */
+const ZEN_FREE_MODEL_METADATA: Record<
+    string,
+    { displayName: string; contextLength: number; vision: boolean; maxTokens: number; thinkingMode: "switchable" | "always"; supportedReasoningEfforts?: string[]; defaultReasoningEffort?: string }
+> = {
+    "big-pickle": {
+        displayName: "Zen/Big Pickle Free",
+        contextLength: 128000,
+        vision: false,
+        maxTokens: 4096,
+        thinkingMode: "always",
+    },
+    "deepseek-v4-flash-free": {
+        displayName: "Zen/DeepSeek V4 Flash Free",
+        contextLength: 1000000,
+        vision: false,
+        maxTokens: 32768,
+        thinkingMode: "switchable",
+        supportedReasoningEfforts: ["high", "max"],
+        defaultReasoningEffort: "max",
+    },
+    "minimax-m2.5-free": {
+        displayName: "Zen/MiniMax M2.5 Free",
+        contextLength: 204800,
+        vision: false,
+        maxTokens: 32768,
+        thinkingMode: "switchable",
+    },
+    "ring-2.6-1t-free": {
+        displayName: "Zen/Ring 2.6 1T Free",
+        contextLength: 128000,
+        vision: false,
+        maxTokens: 4096,
+        thinkingMode: "switchable",
+    },
+    "nemotron-3-super-free": {
+        displayName: "Zen/Nemotron 3 Super Free",
+        contextLength: 128000,
+        vision: false,
+        maxTokens: 4096,
+        thinkingMode: "switchable",
+    },
+};
+
+const EXTENSION_LABEL_ZEN = "OpenCode Zen";
+const ZEN_BASE_URL = "https://opencode.ai/zen/v1/";
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// ── Module-level cache for Zen model list ──
+let cachedModelIds: string[] | null = null;
+let cacheTimestamp = 0;
+
+/**
+ * Fetch the full model list from OpenCode Zen API.
+ * The endpoint follows OpenAI /v1/models format:
+ *   { object: "list", data: [{ id: string, object: string, created: number, owned_by: string }, ...] }
+ */
+async function fetchZenModelList(apiKey: string): Promise<string[]> {
+    const url = `${ZEN_BASE_URL.replace(/\/+$/, "")}/models`;
+    const response = await fetch(url, {
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Zen API error: [${response.status}] ${response.statusText}`);
+    }
+
+    const body = (await response.json()) as { data?: Array<{ id: string }> };
+    return (body.data ?? []).map((m) => m.id);
+}
+
+/**
+ * Build LanguageModelChatInformation array from a list of model IDs.
+ * Only models present in ZEN_FREE_MODEL_METADATA are included.
+ * - switchable models: include "disabled" option so user can turn off thinking
+ * - always models: no "disabled" option, thinking always on
+ */
+function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
+    const infos: LanguageModelChatInformation[] = [];
+
+    for (const modelId of modelIds) {
+        const meta = ZEN_FREE_MODEL_METADATA[modelId];
+        if (!meta) {
+            continue;
+        }
+
+        // Build reasoning effort enum based on thinking mode
+        const hasEfforts = meta.supportedReasoningEfforts && meta.supportedReasoningEfforts.length > 0;
+        let enumValues: string[];
+        if (hasEfforts) {
+            if (meta.thinkingMode === "switchable") {
+                enumValues = ["disabled", ...meta.supportedReasoningEfforts!];
+            } else {
+                enumValues = [...meta.supportedReasoningEfforts!];
+            }
+        } else {
+            if (meta.thinkingMode === "switchable") {
+                enumValues = ["disabled", "enabled"];
+            } else {
+                enumValues = ["enabled"];
+            }
+        }
+        const enumItemLabels = enumValues.map((e) => {
+            switch (e) {
+                case 'disabled': return l10n("Disabled");
+                case 'enabled': return l10n("Thinking");
+                case 'high': return l10n("High");
+                case 'max': return l10n("Maximum");
+                default: return e;
+            }
+        });
+        const enumDescriptions = enumValues.map((e) => {
+            switch (e) {
+                case 'disabled': return l10n("Do not enable thinking");
+                case 'enabled': return l10n("Enable thinking");
+                case 'high': return l10n("Deeper thinking, slower response");
+                case 'max': return l10n("Maximum thinking depth, slowest response");
+                default: return e;
+            }
+        });
+        const defaultEffort = meta.defaultReasoningEffort ?? "enabled";
+
+        infos.push({
+            id: modelId,
+            name: meta.displayName,
+            detail: "OpenCode Zen",
+            tooltip: "OpenCode Zen",
+            family: EXTENSION_LABEL_ZEN,
+            version: "1.0.0",
+            maxInputTokens: meta.contextLength,
+            maxOutputTokens: 0,
+            isUserSelectable: true,
+            capabilities: {
+                toolCalling: true,
+                imageInput: meta.vision,
+            },
+            configurationSchema: {
+                properties: {
+                    reasoningEffort: {
+                        type: "string",
+                        title: l10n("Reasoning Effort"),
+                        enum: enumValues,
+                        enumItemLabels: enumItemLabels,
+                        enumDescriptions: enumDescriptions,
+                        default: defaultEffort,
+                        group: "navigation",
+                    },
+                },
+            },
+        } satisfies LanguageModelChatInformation);
+    }
+
+    return infos;
+}
+
+/**
+ * Get the list of available Zen free models as LanguageModelChatInformation[].
+ *
+ * Flow:
+ * 1. Try to fetch the model list from Zen API (with 5 min cache)
+ * 2. Intersect with hardcoded free model IDs
+ * 3. If API is unreachable or no API key, return the full hardcoded list (optimistic)
+ *
+ * @param secrets SecretStorage instance for reading the API key.
+ */
+export async function getZenFreeModelInfos(secrets: vscode.SecretStorage): Promise<LanguageModelChatInformation[]> {
+    const now = Date.now();
+
+    // Use cached result if still fresh
+    if (cachedModelIds !== null && now - cacheTimestamp < CACHE_TTL_MS) {
+        return buildModelInfos(cachedModelIds);
+    }
+
+    // Try fetching from Zen API
+    const apiKey = await secrets.get("opencodego.apiKey");
+
+    if (apiKey) {
+        try {
+            const allModelIds = await fetchZenModelList(apiKey);
+            // Intersect with hardcoded free model IDs
+            const availableFreeModels = allModelIds.filter((id) => ZEN_FREE_MODEL_IDS.includes(id));
+
+            // Update cache
+            cachedModelIds = availableFreeModels;
+            cacheTimestamp = now;
+
+            return buildModelInfos(availableFreeModels);
+        } catch (error) {
+            console.error("[OpenCodeGo] Failed to fetch Zen model list:", error);
+            // Fall through to use stale cache or full hardcoded list
+        }
+    }
+
+    // Use stale cache if available
+    if (cachedModelIds !== null) {
+        return buildModelInfos(cachedModelIds);
+    }
+
+    // Optimistic: return all hardcoded free models
+    cachedModelIds = [...ZEN_FREE_MODEL_IDS];
+    cacheTimestamp = now;
+    return buildModelInfos(cachedModelIds);
+}
+
+/**
+ * Get model configuration for a Zen free model.
+ * Returns undefined if the model ID is not a known Zen free model.
+ */
+export function getZenFreeModelConfig(modelId: string): OpenCodeGoModelItem | undefined {
+    if (!ZEN_FREE_MODEL_IDS.includes(modelId)) {
+        return undefined;
+    }
+
+    const meta = ZEN_FREE_MODEL_METADATA[modelId];
+    if (!meta) {
+        return undefined;
+    }
+
+    return {
+        id: modelId,
+        owned_by: "opencode",
+        displayName: meta.displayName,
+        baseUrl: ZEN_BASE_URL,
+        vision: meta.vision,
+        context_length: meta.contextLength,
+        max_completion_tokens: meta.maxTokens,
+        apiMode: "openai",
+        enable_thinking: true,
+        include_reasoning_in_request: true,
+        thinkingMode: meta.thinkingMode,
+    };
+}


### PR DESCRIPTION
### Changes

**1. OpenCode Zen Free Model Provider**
- Add `src/zen/zenModels.ts` with 5 hardcoded free model IDs (Big Pickle, DeepSeek V4 Flash, MiniMax M2.5, Ring 2.6 1T, Nemotron 3 Super) and per-model metadata including thinking mode support.
- Fetch model list from Zen API (`/v1/models`), intersect with hardcoded free IDs, cache with 5-minute TTL, and degrade silently on failure.
- Display Zen models with `Zen/` prefix and `Free` suffix in the model picker (e.g. `Zen/DeepSeek V4 Flash Free`), with `detail="OpenCode Zen"` for visual distinction.
- DeepSeek V4 Flash Free supports `disabled`/`high`/`max` reasoning effort levels; other switchable models support `disabled`/`enabled`; Big Pickle has thinking always on.

**2. OpenCode Zen Integration**
- `provideModel.ts` reads `opencodego.enableZenFreeModels` setting and appends Zen models to the picker when enabled.
- `provider.ts` falls back to `getZenFreeModelConfig()` when `getBuiltInModelConfig()` returns undefined, enabling Zen models for chat requests.
- Catch expired free model errors from the API and display a friendly message ("Please use a different model") instead of raw error stacks.

**3. Configuration & i18n**
- Add `opencodego.enableZenFreeModels` setting (default `false`) with documentation explaining the feature, restart requirement, and git commit generation limitation.
- Provide English and Chinese localized descriptions.
- Update `AGENTS.md` and `README.md` with full documentation of the new feature.

### Files Changed

| File | Change |
|------|--------|
| `src/zen/zenModels.ts` | New module: Zen free model definitions, API fetching, caching, config lookup |
| `src/provideModel.ts` | Conditionally append Zen models when setting is enabled |
| `src/provider.ts` | Fallback to Zen model config; catch expired free model errors |
| `src/localize.ts` | Add Chinese error message for expired free models |
| `package.json` | Add `opencodego.enableZenFreeModels` setting |
| `package.nls.json` | Add English description |
| `package.nls.zh-cn.json` | Add Chinese description |
| `README.md` | Document Zen free model feature in both languages |
| `AGENTS.md` | Document Zen module, API, and model definitions |

Close #14 