### PR TITLE
feat: add native Copilot token indicator and migrate to stable VS Code API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 | **Token 计数** | 使用 `o200k_base` tiktoken 分词器精确统计 token 用量 |
 | **状态栏** | 实时显示当前会话 token 使用量、累计用量、缓存命中率 |
 | **原生 Token 指示器** | 始终启用，向 Copilot Chat 原生 Token 指示器报告 token 用量。通过发送 MIME 类型为 `usage` 的 `LanguageModelDataPart`（TextEncoder 编码 JSON）实现，无需自建状态栏。依赖 VS Code/Copilot Chat 1.116+ 对外部模型 `usage` data part 的识别 |
-| **第三方状态栏指示器** | 可通过 `opencodego.enableThirdPartyTokenIndicator` 配置（默认开启）控制 VS Code 状态栏中的自定义 Token 计数器。关闭后仅显示原生指示器 |
+| **高级 Token 指示器** | 可通过 `opencodego.enableThirdPartyTokenIndicator` 配置（默认开启）控制 VS Code 状态栏中的高级Token计数器。关闭后仅显示原生指示器 |
 | **Git 提交消息生成** | 一键生成 Conventional Commit 格式的 Git 提交消息，支持 `auto` 语言模式自动从历史提交检测语言 |
 | **多仓库支持** | 支持多根工作区 (multi-root) 中多个 Git 仓库的提交消息生成 |
 | **模型预设** | 支持通过命令面板快速切换 temperature/top_p 预设（🎯 Precise/⚖️ Balanced/🔥 Creative），也支持手动自定义输入 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@
 | **图片代理 (Tool-based)** | 为不支持视觉的模型注入 `describe_image` 工具，模型可自主选择调用视觉模型（默认 Qwen3.6-Plus）描述图片，支持两轮 API 请求完成"调用工具→获取描述→继续回答"的完整流程。视觉模型 ID、描述提示词和思考模式均可通过设置配置 |
 | **Token 计数** | 使用 `o200k_base` tiktoken 分词器精确统计 token 用量 |
 | **状态栏** | 实时显示当前会话 token 使用量、累计用量、缓存命中率 |
+| **原生 Token 指示器** | 始终启用，向 Copilot Chat 原生 Token 指示器报告 token 用量。通过发送 MIME 类型为 `usage` 的 `LanguageModelDataPart` 实现，无需自建状态栏 |
+| **第三方状态栏指示器** | 可通过 `opencodego.enableThirdPartyTokenIndicator` 配置（默认开启）控制 VS Code 状态栏中的自定义 Token 计数器。关闭后仅显示原生指示器 |
 | **Git 提交消息生成** | 一键生成 Conventional Commit 格式的 Git 提交消息，支持 `auto` 语言模式自动从历史提交检测语言 |
 | **多仓库支持** | 支持多根工作区 (multi-root) 中多个 Git 仓库的提交消息生成 |
 | **模型预设** | 支持通过命令面板快速切换 temperature/top_p 预设（🎯 Precise/⚖️ Balanced/🔥 Creative），也支持手动自定义输入 |
@@ -95,6 +97,8 @@
 │  │   1. 获取模型配置 (getBuiltInModelConfig)                     │  │
 │  │   2. 获取 API Key (SecretStorage)                             │  │
 │  │   3. 计算 Token 用量 (provideToken → statusBar)               │  │
+│  │   3b. 可选: 向 Copilot Chat 原生 Token 指示器报告用量          │  │
+│  │       (LanguageModelDataPart, MIME type "usage")               │  │
 │  │   4. 应用请求延迟 (delay)                                     │  │
 │  │   5. 构建请求 → API 路由选择                                  │  │
 │  │      ├─ apiMode="openai"    → OpenaiApi                       │  │

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 | **图片代理 (Tool-based)** | 为不支持视觉的模型注入 `describe_image` 工具，模型可自主选择调用视觉模型（默认 Qwen3.6-Plus）描述图片，支持两轮 API 请求完成"调用工具→获取描述→继续回答"的完整流程。视觉模型 ID、描述提示词和思考模式均可通过设置配置 |
 | **Token 计数** | 使用 `o200k_base` tiktoken 分词器精确统计 token 用量 |
 | **状态栏** | 实时显示当前会话 token 使用量、累计用量、缓存命中率 |
-| **原生 Token 指示器** | 始终启用，向 Copilot Chat 原生 Token 指示器报告 token 用量。通过发送 MIME 类型为 `usage` 的 `LanguageModelDataPart` 实现，无需自建状态栏 |
+| **原生 Token 指示器** | 始终启用，向 Copilot Chat 原生 Token 指示器报告 token 用量。通过发送 MIME 类型为 `usage` 的 `LanguageModelDataPart`（TextEncoder 编码 JSON）实现，无需自建状态栏。依赖 VS Code/Copilot Chat 1.116+ 对外部模型 `usage` data part 的识别 |
 | **第三方状态栏指示器** | 可通过 `opencodego.enableThirdPartyTokenIndicator` 配置（默认开启）控制 VS Code 状态栏中的自定义 Token 计数器。关闭后仅显示原生指示器 |
 | **Git 提交消息生成** | 一键生成 Conventional Commit 格式的 Git 提交消息，支持 `auto` 语言模式自动从历史提交检测语言 |
 | **多仓库支持** | 支持多根工作区 (multi-root) 中多个 Git 仓库的提交消息生成 |
@@ -98,7 +98,7 @@
 │  │   2. 获取 API Key (SecretStorage)                             │  │
 │  │   3. 计算 Token 用量 (provideToken → statusBar)               │  │
 │  │   3b. 可选: 向 Copilot Chat 原生 Token 指示器报告用量          │  │
-│  │       (LanguageModelDataPart, MIME type "usage")               │  │
+│  │       (LanguageModelDataPart, MIME type "usage", VS Code 1.116+)│  │
 │  │   4. 应用请求延迟 (delay)                                     │  │
 │  │   5. 构建请求 → API 路由选择                                  │  │
 │  │      ├─ apiMode="openai"    → OpenaiApi                       │  │
@@ -1257,12 +1257,19 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 ### 6.7 VS Code API 使用约束
 
 - `LanguageModelChatProvider` — 必须实现 `provideLanguageModelChatResponse()` 和 `provideLanguageModelChatInformation()`
-- `LanguageModelResponsePart2` — 使用 `LanguageModelTextPart`、`LanguageModelThinkingPart`、`LanguageModelToolCallPart`
+- `LanguageModelResponsePart` — 使用 `LanguageModelTextPart`、`LanguageModelThinkingPart`、`LanguageModelToolCallPart`、`LanguageModelDataPart`
+- `LanguageModelChatInformation.maxOutputTokens` — 必须填入模型真实输出上限，不能为 0；VS Code 原生 Token/Context Usage 指示器会在 `maxOutputTokens <= 0` 时隐藏
 - `SecretStorage` — 用于安全存储 API Key
 - `LogOutputChannel` — 用于结构化日志输出
-- `Progress<LanguageModelResponsePart2>` — 用于流式报告响应块
+- `Progress<LanguageModelResponsePart>` — 用于流式报告响应块
 
-### 6.8 错误处理策略
+### 6.8 不依赖 VS Code Proposed API
+
+- 本扩展不使用任何 `enabledApiProposals`，所有使用的 VS Code API 均为稳定版本（VS Code 1.116+）
+- `LanguageModelChatProvider`、`LanguageModelDataPart`、`LanguageModelThinkingPart` 等类型均为 VS Code 稳定 API
+- `languageModelDataPart.d.ts`、`chatProvider.d.ts`、`languageModelThinkingPart.d.ts` 等类型声明文件仅用于编译期类型补全，不影响运行时行为
+
+### 6.9 错误处理策略
 
 - 网络请求使用 `executeWithRetry()`（默认 3 次重试，指数退避）
 - API 认证失败 → 弹出输入框提示用户输入
@@ -1270,7 +1277,7 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 - 流式解析错误 → 记录日志，继续处理（不中断流）
 - 所有未捕获错误由 `provider.ts` 的 `catch` 块统一处理
 
-### 6.9 日志规范
+### 6.10 日志规范
 
 所有日志使用 `logger` 单例，标签格式为 `category.subcategory`：
 - `request.start/end` — 请求开始/结束
@@ -1279,4 +1286,3 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 - `commit.start/end/error` — 提交消息生成
 - `openai.stream.*` / `anthropic.stream.*` — 流式处理
 - `apiKey.missing` — API Key 缺失
-

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Integrate [OpenCode Go](https://opencode.ai/go) and optional Zen free models int
 3. **Select Model**: In the Copilot Chat bottom model picker, choose an "OpenCode Go" or "OpenCode Zen" model
 4. **Start chatting**
 
-### Token Usage Indicator
+### Advanced Token Usage Indicator
 
 Once installed, the status bar shows the current context usage and cumulative input/output token counts for OpenCode Go models. DeepSeek models and models that return cache metrics via the OpenAI-compatible format also display the **cumulative cache hit count** and **cache hit rate** in the tooltip.
+
+You can control this indicator via the `opencodego.enableThirdPartyTokenIndicator` setting (default: `true`). When disabled, only the native Copilot token indicator remains visible.
 
 > [!NOTE]
 > Whether non-DeepSeek models display cache data depends on whether the model API returns cache metrics in an OpenAI-compatible format. This does not indicate whether the model supports caching — caching support depends on OpenCode Go.
@@ -126,9 +128,11 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 3. **选择模型**：在 Copilot Chat 底部模型选择器中选择 "OpenCode Go" 或 "OpenCode Zen" 下的模型
 4. **开始对话**
 
-### Token 用量指示器
+### 高级 Token 用量指示器
 
 安装后，使用 OpenCode Go 提供的模型时，状态栏会显示当前上下文用量与累计输入/输出 Token 量。DeepSeek 和通过 OpenAI 格式返回缓存用量的模型还会显示**累计缓存命中量**与**缓存命中率**。
+
+可通过 `opencodego.enableThirdPartyTokenIndicator` 设置（默认 `true`）控制此高级 Token 指示器。关闭后仅显示 Copilot 原生 Token 指示器。
 
 > [!NOTE]
 > 非 DeepSeek 的模型是否显示缓存数据取决于模型接口是否通过 OpenAI 格式返回缓存数据，这并不代表此模型是否支持缓存。模型对于缓存的支持情况取决于 OpenCode Go。

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,11 @@
 			},
 			"devDependencies": {
 				"@types/node": "^22",
-				"@types/vscode": "^1.104.0",
+				"@types/vscode": "^1.116.0",
 				"typescript": "^5.9.2"
 			},
 			"engines": {
-				"vscode": "^1.104.0"
+				"vscode": "^1.116.0"
 			}
 		},
 		"node_modules/@microsoft/tiktokenizer": {

--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "%config.visionProxyThinking.desc%"
+				},
+				"opencodego.enableThirdPartyTokenIndicator": {
+					"type": "boolean",
+					"default": true,
+					"description": "%config.enableThirdPartyTokenIndicator.desc%"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -24,18 +24,15 @@
 	"bugs": {
 		"url": "https://github.com/OnesoftQwQ/opencode-go-copilot/issues"
 	},
-	"version": "1.2.0",
+	"version": "1.2.2",
 	"engines": {
-		"vscode": "^1.104.0"
+		"vscode": "^1.116.0"
 	},
 	"categories": [
 		"AI",
 		"Chat"
 	],
 	"license": "MIT",
-	"enabledApiProposals": [
-		"chatProvider"
-	],
 	"contributes": {
 		"languageModelChatProviders": [
 			{
@@ -281,7 +278,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22",
-		"@types/vscode": "^1.104.0",
+		"@types/vscode": "^1.116.0",
 		"typescript": "^5.9.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -26,16 +26,13 @@
 	},
 	"version": "1.3.0",
 	"engines": {
-		"vscode": "^1.104.0"
+		"vscode": "^1.116.0"
 	},
 	"categories": [
 		"AI",
 		"Chat"
 	],
 	"license": "MIT",
-	"enabledApiProposals": [
-		"chatProvider"
-	],
 	"contributes": {
 		"languageModelChatProviders": [
 			{
@@ -281,7 +278,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22",
-		"@types/vscode": "^1.104.0",
+		"@types/vscode": "^1.116.0",
 		"typescript": "^5.9.2"
 	}
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -44,6 +44,7 @@
 	"config.visionProxyModel.desc": "Vision model ID used by the describe_image tool to describe attached images when the selected model does not support vision.",
 	"config.visionProxyPrompt.desc": "Custom prompt sent to the vision model when describing an image via the describe_image tool.",
 	"config.visionProxyThinking.desc": "Enable thinking/reasoning when describing images via the vision proxy model.",
+	"config.enableThirdPartyTokenIndicator.desc": "Enable the third-party status bar token usage indicator. The native Copilot token indicator always shows. When this is enabled, the extension also shows a custom token counter in the VS Code status bar. Default: true.",
 
 	"command.setModelPreset": "Set Model Temperature Preset"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -44,7 +44,7 @@
 	"config.visionProxyModel.desc": "Vision model ID used by the describe_image tool to describe attached images when the selected model does not support vision.",
 	"config.visionProxyPrompt.desc": "Custom prompt sent to the vision model when describing an image via the describe_image tool.",
 	"config.visionProxyThinking.desc": "Enable thinking/reasoning when describing images via the vision proxy model.",
-	"config.enableThirdPartyTokenIndicator.desc": "Enable the third-party status bar token usage indicator. The native Copilot token indicator always shows. When this is enabled, the extension also shows a custom token counter in the VS Code status bar. Default: true.",
+	"config.enableThirdPartyTokenIndicator.desc": "Enable the Advanced Token indicator in the status bar. The native Copilot token indicator always shows. When this is enabled, the extension also shows an advanced token counter in the VS Code status bar. Default: true.",
 
 	"command.setModelPreset": "Set Model Temperature Preset"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -44,6 +44,7 @@
 	"config.visionProxyModel.desc": "用于 describe_image 工具的视觉模型 ID。当所选模型不支持视觉时，该模型用于描述附带的图片。",
 	"config.visionProxyPrompt.desc": "发送给视觉模型的图片描述提示词。可通过 describe_image 工具调用。",
 	"config.visionProxyThinking.desc": "在视觉代理模型描述图片时启用思考/推理功能。",
+	"config.enableThirdPartyTokenIndicator.desc": "启用第三方状态栏 Token 用量指示器。Copilot 原生 Token 指示器始终保持开启。开启后，扩展还会在 VS Code 状态栏中显示自定义 Token 计数器。默认: 开启。",
 
 	"command.setModelPreset": "设置模型温度预设"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -44,7 +44,7 @@
 	"config.visionProxyModel.desc": "用于 describe_image 工具的视觉模型 ID。当所选模型不支持视觉时，该模型用于描述附带的图片。",
 	"config.visionProxyPrompt.desc": "发送给视觉模型的图片描述提示词。可通过 describe_image 工具调用。",
 	"config.visionProxyThinking.desc": "在视觉代理模型描述图片时启用思考/推理功能。",
-	"config.enableThirdPartyTokenIndicator.desc": "启用第三方状态栏 Token 用量指示器。Copilot 原生 Token 指示器始终保持开启。开启后，扩展还会在 VS Code 状态栏中显示自定义 Token 计数器。默认: 开启。",
+	"config.enableThirdPartyTokenIndicator.desc": "启用高级 Token 指示器。Copilot 原生 Token 指示器始终保持开启。开启后，扩展还会在 VS Code 状态栏中显示高级Token计数器。默认: 开启。",
 
 	"command.setModelPreset": "设置模型温度预设"
 }

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -33,6 +33,9 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 	/** Whether images were stored during convertMessages for describe_image tool. */
 	private _hasStoredImages = false;
 
+	/** Accumulated input tokens from Anthropic message_start for usage reporting. */
+	private _anthropicInputTokens = 0;
+
 	/**
 	 * Convert VS Code chat messages to Anthropic message format.
 	 * @param messages The VS Code chat messages to convert.
@@ -378,12 +381,24 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		}
 
 		if (chunk.type === "message_start" && chunk.message) {
-			// Extract message metadata (id, model, etc.)
+			// Extract message metadata (id, model, etc.) and input token count
+			const msg = chunk.message as Record<string, unknown>;
+			const usage = msg.usage as { input_tokens?: number } | undefined;
+			if (usage?.input_tokens) {
+				this._anthropicInputTokens = usage.input_tokens;
+			}
 			return;
 		}
 
 		if (chunk.type === "message_delta" && chunk.delta) {
 			// Extract stop_reason and usage information
+			const chunkUsage = chunk.usage as { output_tokens?: number } | undefined;
+			if (chunkUsage?.output_tokens && this._anthropicInputTokens > 0) {
+				this._onUsage?.({
+					promptTokens: this._anthropicInputTokens,
+					completionTokens: chunkUsage.output_tokens,
+				});
+			}
 			return;
 		}
 

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -2,8 +2,8 @@ import * as vscode from "vscode";
 import {
 	CancellationToken,
 	LanguageModelChatRequestMessage,
+	LanguageModelResponsePart,
 	ProvideLanguageModelChatResponseOptions,
-	LanguageModelResponsePart2,
 	Progress,
 } from "vscode";
 
@@ -287,7 +287,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 	 */
 	async processStreamingResponse(
 		responseBody: ReadableStream<Uint8Array>,
-		progress: Progress<LanguageModelResponsePart2>,
+		progress: Progress<LanguageModelResponsePart>,
 		token: CancellationToken
 	): Promise<void> {
 		const modelId = this._modelId;
@@ -365,7 +365,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 	 */
 	private async processAnthropicChunk(
 		chunk: AnthropicStreamChunk,
-		progress: Progress<LanguageModelResponsePart2>
+		progress: Progress<LanguageModelResponsePart>
 	): Promise<void> {
 		// Handle ping events (ignore)
 		if (chunk.type === "ping") {

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -1,9 +1,9 @@
 import * as vscode from "vscode";
 import {
+    LanguageModelResponsePart,
     ProvideLanguageModelChatResponseOptions,
     LanguageModelChatRequestMessage,
     LanguageModelToolCallPart,
-    LanguageModelResponsePart2,
     LanguageModelThinkingPart,
     Progress,
     CancellationToken,
@@ -161,7 +161,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      */
     abstract processStreamingResponse(
         responseBody: ReadableStream<Uint8Array>,
-        progress: Progress<LanguageModelResponsePart2>,
+        progress: Progress<LanguageModelResponsePart>,
         token: CancellationToken
     ): Promise<void>;
 
@@ -172,7 +172,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      */
     protected async tryEmitBufferedToolCall(
         index: number,
-        progress: Progress<LanguageModelResponsePart2>
+        progress: Progress<LanguageModelResponsePart>
     ): Promise<void> {
         const buf = this._toolCallBuffers.get(index);
         if (!buf) {
@@ -203,7 +203,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      * @param throwOnInvalid If true, throw when a tool call has invalid JSON args.
      */
     protected async flushToolCallBuffers(
-        progress: Progress<LanguageModelResponsePart2>,
+        progress: Progress<LanguageModelResponsePart>,
         throwOnInvalid: boolean
     ): Promise<void> {
         if (this._toolCallBuffers.size === 0) {
@@ -276,13 +276,13 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      * Report to VS Code for ending thinking
      * @param progress Progress reporter for parts
      */
-    protected reportEndThinking(progress: Progress<LanguageModelResponsePart2>) {
+    protected reportEndThinking(progress: Progress<LanguageModelResponsePart>) {
         if (!this._currentThinkingId) {
             return;
         }
         try {
             this.flushThinkingBuffer(progress);
-            progress.report(new LanguageModelThinkingPart("", this._currentThinkingId));
+            progress.report(new LanguageModelThinkingPart("", this._currentThinkingId) as unknown as LanguageModelResponsePart);
         } catch (e) {
             console.error("[OpenCodeGo] Failed to end thinking sequence:", e);
         }
@@ -306,7 +306,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      * @param text The thinking text to buffer
      * @param progress Progress reporter for parts
      */
-    protected bufferThinkingContent(text: string, progress: Progress<LanguageModelResponsePart2>): void {
+    protected bufferThinkingContent(text: string, progress: Progress<LanguageModelResponsePart>): void {
         this._hasEmittedThinking = true;
         if (!this._currentThinkingId) {
             this._currentThinkingId = this.generateThinkingId();
@@ -325,7 +325,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      * Flush the thinking buffer to the progress reporter.
      * @param progress Progress reporter for parts.
      */
-    protected flushThinkingBuffer(progress: Progress<LanguageModelResponsePart2>): void {
+    protected flushThinkingBuffer(progress: Progress<LanguageModelResponsePart>): void {
         if (this._thinkingFlushTimer) {
             clearTimeout(this._thinkingFlushTimer);
             this._thinkingFlushTimer = null;
@@ -334,7 +334,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
         if (this._thinkingBuffer && this._currentThinkingId) {
             const text = this._thinkingBuffer;
             this._thinkingBuffer = "";
-            progress.report(new LanguageModelThinkingPart(text, this._currentThinkingId));
+            progress.report(new LanguageModelThinkingPart(text, this._currentThinkingId) as unknown as LanguageModelResponsePart);
         }
     }
 
@@ -346,7 +346,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      */
     protected processXmlThinkBlocks(
         content: string,
-        progress: Progress<LanguageModelResponsePart2>
+        progress: Progress<LanguageModelResponsePart>
     ): { emittedAny: boolean } {
         if (!content.includes("꽁") && !content.includes("ground") && !this._xmlThinkActive) {
             return { emittedAny: false };
@@ -409,7 +409,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      */
     protected processTextContent(
         content: string,
-        progress: Progress<LanguageModelResponsePart2>
+        progress: Progress<LanguageModelResponsePart>
     ): { emittedAny: boolean } {
         if (!content) {
             return { emittedAny: false };

--- a/src/models.ts
+++ b/src/models.ts
@@ -90,7 +90,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
             family: EXTENSION_LABEL,
             version: "1.0.0",
             maxInputTokens: maxInput,
-            maxOutputTokens: 0,
+            maxOutputTokens: def.maxTokens ?? DEFAULT_MAX_TOKENS,
             isUserSelectable: true,
             capabilities: {
                 toolCalling: true,

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -2,8 +2,8 @@ import * as vscode from "vscode";
 import {
     CancellationToken,
     LanguageModelChatRequestMessage,
+    LanguageModelResponsePart,
     ProvideLanguageModelChatResponseOptions,
-    LanguageModelResponsePart2,
     Progress,
 } from "vscode";
 
@@ -294,7 +294,7 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
      */
     async processStreamingResponse(
         responseBody: ReadableStream<Uint8Array>,
-        progress: Progress<LanguageModelResponsePart2>,
+        progress: Progress<LanguageModelResponsePart>,
         token: CancellationToken
     ): Promise<void> {
         const modelId = this._modelId;
@@ -397,7 +397,7 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
      */
     private async processDelta(
         delta: Record<string, unknown>,
-        progress: Progress<LanguageModelResponsePart2>
+        progress: Progress<LanguageModelResponsePart>
     ): Promise<boolean> {
         let emitted = false;
         const choice = (delta.choices as Record<string, unknown>[] | undefined)?.[0];

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -25,12 +25,42 @@ import { updateContextStatusBar, recordUsage, updateCumulativeTooltip } from "./
 import { OpenaiApi } from "./openai/openaiApi";
 import { AnthropicApi } from "./anthropic/anthropicApi";
 import type { AnthropicRequestBody } from "./anthropic/anthropicTypes";
-import { CommonApi } from "./commonApi";
+import { CommonApi, type StreamUsage } from "./commonApi";
 import { callVisionModel } from "./vision/imageProxy";
 import { DESCRIBE_IMAGE_TOOL_NAME } from "./vision/types";
 import type { InterceptedToolCall, StoredImage } from "./vision/types";
 import { logger } from "./logger";
 import { l10n } from "./localize";
+
+/**
+ * Native Copilot Token Indicator
+ *
+ * Reports token usage to the Copilot Chat's built-in token indicator by emitting
+ * a LanguageModelDataPart with MIME type 'usage'. Copilot Chat intercepts this
+ * part and displays it in the native UI element, just like GitHub Copilot's own
+ * models do.
+ *
+ * This is always active. The separate third-party status bar indicator can be
+ * controlled via the "opencodego.enableThirdPartyTokenIndicator" setting.
+ */
+function reportNativeUsage(
+    usage: StreamUsage,
+    progress: Progress<LanguageModelResponsePart2>
+): void {
+    progress.report(
+        new vscode.LanguageModelDataPart(
+            new TextEncoder().encode(JSON.stringify({
+                prompt_tokens: usage.promptTokens,
+                completion_tokens: usage.completionTokens,
+                total_tokens: usage.promptTokens + usage.completionTokens,
+                prompt_tokens_details: {
+                    cached_tokens: usage.cacheHitTokens ?? 0,
+                },
+            })),
+            'usage'
+        )
+    );
+}
 
 /**
  * VS Code Chat provider backed by OpenCode Go API.
@@ -187,8 +217,13 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 vision: um?.vision ?? false,
             };
 
-            // Update Token Usage
-            updateContextStatusBar(messages, options.tools, model, this.statusBarItem, modelConfig);
+            // Read third-party status bar indicator setting
+            const enableThirdPartyIndicator = config.get<boolean>("opencodego.enableThirdPartyTokenIndicator", true);
+
+            // Update third-party status bar (if enabled)
+            if (enableThirdPartyIndicator) {
+                updateContextStatusBar(messages, options.tools, model, this.statusBarItem, modelConfig);
+            }
 
             // Apply delay between consecutive requests
             const modelDelay = um?.delay;
@@ -250,6 +285,15 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             if (apiMode === "anthropic") {
                 // Anthropic API mode
                 const anthropicApi = new AnthropicApi(model.id);
+                anthropicApi.onUsage = (usage) => {
+                    // Always report to native Copilot indicator
+                    reportNativeUsage(usage, trackingProgress);
+                    // Conditionally update third-party status bar
+                    if (enableThirdPartyIndicator) {
+                        recordUsage(usage);
+                        updateCumulativeTooltip(this.statusBarItem);
+                    }
+                };
                 const anthropicMessages = anthropicApi.convertMessages(messages, modelConfig);
 
                 // requestBody
@@ -312,8 +356,13 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 // OpenAI Chat Completions API mode
                 const openaiApi = new OpenaiApi(model.id);
                 openaiApi.onUsage = (usage) => {
-                    recordUsage(usage);
-                    updateCumulativeTooltip(this.statusBarItem);
+                    // Always report to native Copilot indicator
+                    reportNativeUsage(usage, trackingProgress);
+                    // Conditionally update third-party status bar
+                    if (enableThirdPartyIndicator) {
+                        recordUsage(usage);
+                        updateCumulativeTooltip(this.statusBarItem);
+                    }
                 };
                 const openaiMessages = openaiApi.convertMessages(messages, modelConfig);
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -40,7 +40,7 @@ import { l10n } from "./localize";
  * part and displays it in the native UI element, just like GitHub Copilot's own
  * models do.
  *
- * This is always active. The separate third-party status bar indicator can be
+ * This is always active. The separate Advanced Token indicator can be
  * controlled via the "opencodego.enableThirdPartyTokenIndicator" setting.
  */
 function reportNativeUsage(
@@ -217,10 +217,10 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 vision: um?.vision ?? false,
             };
 
-            // Read third-party status bar indicator setting
+            // Read Advanced Token indicator setting
             const enableThirdPartyIndicator = config.get<boolean>("opencodego.enableThirdPartyTokenIndicator", true);
 
-            // Update third-party status bar (if enabled)
+            // Update Advanced Token indicator (if enabled)
             if (enableThirdPartyIndicator) {
                 updateContextStatusBar(messages, options.tools, model, this.statusBarItem, modelConfig);
             }
@@ -288,7 +288,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 anthropicApi.onUsage = (usage) => {
                     // Always report to native Copilot indicator (use original progress, not trackingProgress wrapper)
                     reportNativeUsage(usage, progress);
-                    // Conditionally update third-party status bar
+                    // Conditionally update Advanced Token indicator
                     if (enableThirdPartyIndicator) {
                         recordUsage(usage);
                         updateCumulativeTooltip(this.statusBarItem);
@@ -358,7 +358,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 openaiApi.onUsage = (usage) => {
                     // Always report to native Copilot indicator (use original progress, not trackingProgress wrapper)
                     reportNativeUsage(usage, progress);
-                    // Conditionally update third-party status bar
+                    // Conditionally update Advanced Token indicator
                     if (enableThirdPartyIndicator) {
                         recordUsage(usage);
                         updateCumulativeTooltip(this.statusBarItem);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,9 +4,9 @@ import {
     LanguageModelChatInformation,
     LanguageModelChatProvider,
     LanguageModelChatRequestMessage,
+    LanguageModelResponsePart,
     PrepareLanguageModelChatModelOptions,
     ProvideLanguageModelChatResponseOptions,
-    LanguageModelResponsePart2,
     Progress,
 } from "vscode";
 
@@ -45,7 +45,7 @@ import { l10n } from "./localize";
  */
 function reportNativeUsage(
     usage: StreamUsage,
-    progress: Progress<LanguageModelResponsePart2>
+    progress: Progress<LanguageModelResponsePart>
 ): void {
     progress.report(
         new vscode.LanguageModelDataPart(
@@ -123,10 +123,10 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         model: LanguageModelChatInformation,
         messages: readonly LanguageModelChatRequestMessage[],
         options: ProvideLanguageModelChatResponseOptions,
-        progress: Progress<LanguageModelResponsePart2>,
+        progress: Progress<LanguageModelResponsePart>,
         token: CancellationToken
     ): Promise<void> {
-        const trackingProgress: Progress<LanguageModelResponsePart2> = {
+        const trackingProgress: Progress<LanguageModelResponsePart> = {
             report: (part) => {
                 try {
                     progress.report(part);
@@ -286,8 +286,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 // Anthropic API mode
                 const anthropicApi = new AnthropicApi(model.id);
                 anthropicApi.onUsage = (usage) => {
-                    // Always report to native Copilot indicator
-                    reportNativeUsage(usage, trackingProgress);
+                    // Always report to native Copilot indicator (use original progress, not trackingProgress wrapper)
+                    reportNativeUsage(usage, progress);
                     // Conditionally update third-party status bar
                     if (enableThirdPartyIndicator) {
                         recordUsage(usage);
@@ -356,8 +356,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 // OpenAI Chat Completions API mode
                 const openaiApi = new OpenaiApi(model.id);
                 openaiApi.onUsage = (usage) => {
-                    // Always report to native Copilot indicator
-                    reportNativeUsage(usage, trackingProgress);
+                    // Always report to native Copilot indicator (use original progress, not trackingProgress wrapper)
+                    reportNativeUsage(usage, progress);
                     // Conditionally update third-party status bar
                     if (enableThirdPartyIndicator) {
                         recordUsage(usage);
@@ -493,7 +493,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         requestHeaders: Record<string, string>;
         retryConfig: ReturnType<typeof createRetryConfig>;
         abortController: AbortController;
-        trackingProgress: Progress<LanguageModelResponsePart2>;
+        trackingProgress: Progress<LanguageModelResponsePart>;
         token: CancellationToken;
     }): Promise<void> {
         const intercepted = params.api.interceptedToolCall;
@@ -525,7 +525,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         // Emit a brief thinking indicator BEFORE reading the image
         const visionThinkId = `vision_${Date.now()}`;
         params.trackingProgress.report(
-            new vscode.LanguageModelThinkingPart(l10n("Reading image..."), visionThinkId)
+            new vscode.LanguageModelThinkingPart(l10n("Reading image..."), visionThinkId) as unknown as LanguageModelResponsePart
         );
 
         // Call vision model to describe the image (result is for internal use only)
@@ -547,10 +547,10 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         // Append "done" to the thinking block, then close it.
         // The description is only for the model (second round via tool_result).
         params.trackingProgress.report(
-            new vscode.LanguageModelThinkingPart(l10n(" done"), visionThinkId)
+            new vscode.LanguageModelThinkingPart(l10n(" done"), visionThinkId) as unknown as LanguageModelResponsePart
         );
         params.trackingProgress.report(
-            new vscode.LanguageModelThinkingPart("", visionThinkId)
+            new vscode.LanguageModelThinkingPart("", visionThinkId) as unknown as LanguageModelResponsePart
         );
 
         // Build second-round messages and make another API request

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -150,7 +150,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
             family: EXTENSION_LABEL_ZEN,
             version: "1.0.0",
             maxInputTokens: meta.contextLength,
-            maxOutputTokens: 0,
+            maxOutputTokens: meta.maxTokens,
             isUserSelectable: true,
             capabilities: {
                 toolCalling: true,


### PR DESCRIPTION
### Changes

**1. Native Copilot Token Indicator**
- Added `reportNativeUsage()` function that reports token usage to Copilot Chat's built-in token indicator via `LanguageModelDataPart` with MIME type `usage`, eliminating the need for a custom status bar for basic usage tracking.
- Both OpenAI and Anthropic API modes now emit usage data to the native indicator — Anthropic mode additionally captures input tokens from `message_start` event.
- The original `progress` reporter is used for native usage reporting instead of the `trackingProgress` wrapper, ensuring correct behavior.

**2. Advanced Token Indicator Toggle**
- Added new setting `opencodego.enableThirdPartyTokenIndicator` (default: `true`) to control the custom status bar token counter independently from the always-on native indicator.
- When disabled, the extension no longer displays its own status bar token counter, relying solely on the Copilot native indicator.
- Renamed "third-party token indicator" to "advanced token indicator" for clarity across documentation, settings descriptions, and code comments.

**3. Migration to Stable VS Code API**
- Removed `enabledApiProposals: ["chatProvider"]` — the extension no longer depends on any proposed APIs.
- Migrated from `LanguageModelResponsePart2` to the stable `LanguageModelResponsePart` type across all API implementations.
- Updated VS Code engine requirement from `^1.104.0` to `^1.116.0`, and `@types/vscode` accordingly.

**4. Corrected maxOutputTokens**
- Fixed `maxOutputTokens` from `0` to the actual model-defined max tokens for both built-in models and Zen free models. This enables the VS Code native Token/Context Usage indicator, which hides when `maxOutputTokens <= 0`.
- Added documentation in AGENTS.md describing this constraint.

**5. Documentation Updates**
- Updated AGENTS.md with new sections on native token indicator, stable API dependency, and VS Code API usage constraints.
- Updated README.md (EN and ZH) with advanced token indicator setting description.

### Files Changed

| File | Change |
|------|--------|
| `src/provider.ts` | Added `reportNativeUsage()` and third-party indicator toggle logic |
| `src/commonApi.ts` | Migrated to stable `LanguageModelResponsePart` type |
| `src/openai/openaiApi.ts` | Migrated to stable type; onUsage reports to native indicator |
| `src/anthropic/anthropicApi.ts` | Captured input tokens from message_start; migrated to stable type |
| `src/models.ts` | Fixed `maxOutputTokens` to use actual model max tokens |
| `src/zen/zenModels.ts` | Fixed `maxOutputTokens` for Zen models |
| `package.json` | Removed `enabledApiProposals`; bumped engine/types to 1.116.0; added new setting |
| `package.nls.json` | Added/updated setting descriptions for token indicator |
| `package.nls.zh-cn.json` | Added/updated setting descriptions in Chinese |
| `README.md` | Updated token indicator documentation for EN and ZH |
| `AGENTS.md` | Updated documentation reflecting all changes |