### PR TITLE
feat: add install welcome walkthrough for first-time users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@
 | **超时控制** | 可配置的请求超时时间（默认 10 分钟） |
 | **立即取消** | 取消请求时通过 `reader.cancel()` 立即中断流式读取，停止后台接收 |
 | **视觉代理配置** | 支持通过设置 `opencodego.visionProxyModel`、`opencodego.visionProxyPrompt`、`opencodego.visionProxyThinking` 配置图片代理所使用的视觉模型、提示词和思考模式 |
+| **安装欢迎页 (Walkthrough)** | 首次安装且未配置 API Key 时自动打开引导向导，指引用户设置 API Key 和打开语言模型管理器。包含 3 个步骤：设置 API Key、显示模型、高级设置。通过 `onStartupFinished` 激活事件确保在 VS Code 启动后立即检测 |
 
 ### 1.3 模型清单
 
@@ -125,16 +126,19 @@
 
 ```
 activate(context)
-  ├── logger.init()                    ← 创建 LogOutputChannel
-  ├── TokenizerManager.initialize()    ← 加载 o200k_base.tiktoken
-  ├── initStatusBar()                  ← 创建状态栏条目
-  ├── new OpenCodeGoChatModelProvider() ← 创建 Provider 实例
+  ├── logger.init()                         ← 创建 LogOutputChannel
+  ├── TokenizerManager.initialize()         ← 加载 o200k_base.tiktoken
+  ├── initStatusBar()                       ← 创建状态栏条目
+  ├── new OpenCodeGoChatModelProvider()      ← 创建 Provider 实例
   ├── vscode.lm.registerLanguageModelChatProvider("opencodego", provider)
   ├── 注册命令:
   │   ├── opencodego.setApiKey                ← 设置 API Key
+  │   ├── opencodego.getApiKey                ← 打开 OpenCode AI 官网获取 Key
+  │   ├── opencodego.openSettings             ← 打开扩展设置页
   │   ├── opencodego.generateGitCommitMessage ← 生成提交消息
   │   ├── opencodego.abortGitCommitMessage    ← 中止生成
   │   └── opencodego.setModelPreset           ← 设置模型预设
+  ├── showWelcomeIfNeeded()                 ← 首次安装时显示欢迎向导
   └── 注册 dispose 清理
 ```
 
@@ -375,15 +379,23 @@ src/
 ├── vision/
 │   ├── types.ts                          # Vision proxy 类型定义
 │   └── imageProxy.ts                     # 图片代理核心 (describe_image)
-└── zen/
-    └── zenModels.ts                      # Zen 免费模型定义与 API 交互
+├── zen/
+│   └── zenModels.ts                      # Zen 免费模型定义与 API 交互
+└── resources/
+    └── walkthrough/                      # 安装欢迎页 (Walkthrough) 文档
+        ├── set-api-key.md                # 步骤 1：设置 API Key
+        ├── set-api-key.nls.zh-cn.md      # 步骤 1 中文版
+        ├── show-models.md                # 步骤 2：显示模型
+        ├── show-models.nls.zh-cn.md      # 步骤 2 中文版
+        ├── advanced-settings.md          # 步骤 3：高级设置
+        └── advanced-settings.nls.zh-cn.md# 步骤 3 中文版
 ```
 
 ### 3.2 文件详细说明
 
 | 文件 | 行数 | 职责 |
 |------|------|------|
-| `extension.ts` | ~175 | 扩展激活/停用，注册 Provider 和 4 条命令 |
+| `extension.ts` | ~210 | 扩展激活/停用，注册 Provider 和 6 条命令，首次安装欢迎页引导 |
 | `provider.ts` | ~670 | 实现 `LanguageModelChatProvider`，处理聊天请求全流程及图片代理第二轮处理 |
 | `models.ts` | ~218 | 14 个内置模型定义，模型配置查询（所有模型声明 `imageInput: true`） |
 | `types.ts` | ~95 | `OpenCodeGoModelItem`, `ModelPreset`, `ModelsResponse`, `RetryConfig` 等类型 |
@@ -414,7 +426,10 @@ src/
 ### 4.1 `src/extension.ts`
 
 #### `activate(context: vscode.ExtensionContext): void`
-扩展激活入口。初始化日志、分词器、状态栏；注册 `LanguageModelChatProvider`；注册四条命令（设置 API Key、生成 Git 提交消息、中止生成、设置模型预设）。
+扩展激活入口。初始化日志、分词器、状态栏；注册 `LanguageModelChatProvider`；注册六条命令（设置 API Key、获取 API Key 网址、打开扩展设置、生成 Git 提交消息、中止生成、设置模型预设）；首次安装时调用 `showWelcomeIfNeeded()` 显示欢迎页引导。
+
+#### `showWelcomeIfNeeded(context: vscode.ExtensionContext): Promise<void>`
+检查是否已显示过欢迎页（通过 `globalState` 的 `WELCOME_SHOWN_KEY` 标记）。如果已标记或已有 API Key，直接返回；否则通过 `workbench.action.openWalkthrough` 命令打开 Walkthrough 页面并标记为已显示。静默处理异常，不阻塞扩展激活。
 
 #### `deactivate(): void`
 扩展停用。清理资源（日志 dispose）。

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
 		"Chat"
 	],
 	"license": "MIT",
+	"activationEvents": [
+		"onStartupFinished"
+	],
 	"contributes": {
 		"languageModelChatProviders": [
 			{
@@ -46,6 +49,16 @@
 				"command": "opencodego.setApiKey",
 				"category": "%commandCategory%",
 				"title": "%command.setApiKey%"
+			},
+			{
+				"command": "opencodego.getApiKey",
+				"category": "%commandCategory%",
+				"title": "%command.getApiKey%"
+			},
+			{
+				"command": "opencodego.openSettings",
+				"category": "%commandCategory%",
+				"title": "%command.openSettings%"
 			},
 			{
 				"command": "opencodego.generateGitCommitMessage",
@@ -63,6 +76,42 @@
 				"command": "opencodego.setModelPreset",
 				"category": "%commandCategory%",
 				"title": "%command.setModelPreset%"
+			}
+		],
+		"walkthroughs": [
+			{
+				"id": "opencodeGoGettingStarted",
+				"title": "%walkthrough.title%",
+				"description": "%walkthrough.description%",
+				"steps": [
+					{
+						"id": "setApiKey",
+						"title": "%walkthrough.setApiKey.title%",
+						"description": "%walkthrough.setApiKey.description%",
+						"media": {
+							"markdown": "resources/walkthrough/set-api-key.md"
+						},
+						"completionEvents": [
+							"onCommand:opencodego.setApiKey"
+						]
+					},
+					{
+						"id": "showModels",
+						"title": "%walkthrough.showModels.title%",
+						"description": "%walkthrough.showModels.description%",
+						"media": {
+							"markdown": "resources/walkthrough/show-models.md"
+						}
+					},
+					{
+						"id": "advancedSettings",
+						"title": "%walkthrough.advancedSettings.title%",
+						"description": "%walkthrough.advancedSettings.description%",
+						"media": {
+							"markdown": "resources/walkthrough/advanced-settings.md"
+						}
+					}
+				]
 			}
 		],
 		"menus": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,6 +3,8 @@
 	"commandCategory": "OpenCodeGo",
 
 	"command.setApiKey": "Set OpenCode Go API Key",
+	"command.getApiKey": "Get OpenCode Go API Key",
+	"command.openSettings": "Open OpenCode Go Settings",
 	"command.generateCommit": "Generate Commit Message with OpenCodeGo",
 	"command.abortCommit": "Generate Commit Message with OpenCodeGo - Stop",
 
@@ -46,5 +48,14 @@
 	"config.visionProxyThinking.desc": "Enable thinking/reasoning when describing images via the vision proxy model.",
 	"config.enableThirdPartyTokenIndicator.desc": "Enable the Advanced Token indicator in the status bar. The native Copilot token indicator always shows. When this is enabled, the extension also shows an advanced token counter in the VS Code status bar. Default: true.",
 
-	"command.setModelPreset": "Set Model Temperature Preset"
+	"command.setModelPreset": "Set Model Temperature Preset",
+
+	"walkthrough.title": "OpenCode Go for Copilot Chat",
+	"walkthrough.description": "Set up OpenCode Go models in Copilot Chat.",
+	"walkthrough.setApiKey.title": "Set your OpenCode Go API key",
+	"walkthrough.setApiKey.description": "[Get an API key](command:opencodego.getApiKey) from opencode.ai.\n[Set API Key](command:opencodego.setApiKey)",
+	"walkthrough.showModels.title": "Show OpenCode Go models",
+	"walkthrough.showModels.description": "If the models are hidden, open VS Code's Language Models manager and show the OpenCode Go models.\n[Open Language Models](command:workbench.action.chat.manage)",
+	"walkthrough.advancedSettings.title": "Explore advanced settings",
+	"walkthrough.advancedSettings.description": "Customize model presets, enable Zen free models, configure vision proxy, and more.\n[Open settings](command:opencodego.openSettings)"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -3,6 +3,8 @@
 	"commandCategory": "OpenCodeGo",
 
 	"command.setApiKey": "设置 OpenCode Go API 密钥",
+	"command.getApiKey": "获取 OpenCode Go API 密钥",
+	"command.openSettings": "打开 OpenCode Go 设置",
 	"command.generateCommit": "使用 OpenCodeGo 生成提交消息",
 	"command.abortCommit": "使用 OpenCodeGo 生成提交消息 - 停止",
 
@@ -46,5 +48,14 @@
 	"config.visionProxyThinking.desc": "在视觉代理模型描述图片时启用思考/推理功能。",
 	"config.enableThirdPartyTokenIndicator.desc": "启用高级 Token 指示器。Copilot 原生 Token 指示器始终保持开启。开启后，扩展还会在 VS Code 状态栏中显示高级Token计数器。默认: 开启。",
 
-	"command.setModelPreset": "设置模型温度预设"
+	"command.setModelPreset": "设置模型温度预设",
+
+	"walkthrough.title": "OpenCode Go for Copilot Chat",
+	"walkthrough.description": "在 Copilot Chat 中配置 OpenCode Go 模型。",
+	"walkthrough.setApiKey.title": "设置你的 OpenCode Go API 密钥",
+	"walkthrough.setApiKey.description": "[获取 API 密钥](command:opencodego.getApiKey)。\n[设置 API 密钥](command:opencodego.setApiKey)",
+	"walkthrough.showModels.title": "显示 OpenCode Go 模型",
+	"walkthrough.showModels.description": "如果模型被隐藏，请打开 VS Code 的语言模型管理器并显示 OpenCode Go 模型。\n[打开语言模型管理](command:workbench.action.chat.manage)",
+	"walkthrough.advancedSettings.title": "探索高级设置",
+	"walkthrough.advancedSettings.description": "自定义模型预设、启用 Zen 免费模型、配置视觉代理等。\n[打开设置](command:opencodego.openSettings)"
 }

--- a/resources/walkthrough/advanced-settings.md
+++ b/resources/walkthrough/advanced-settings.md
@@ -1,0 +1,11 @@
+## Advanced Settings
+
+Customize your OpenCode Go experience through the extension settings:
+
+- **Model Presets**: Quickly switch between Precise, Balanced, Creative, or custom temperature/top_p values via the command palette.
+- **Zen Free Models**: Enable `opencodego.enableZenFreeModels` to add free OpenCode Zen models to the picker.
+- **Vision Proxy**: Configure which vision model is used to describe images for non-vision models.
+- **Git Commit**: Customize commit message language, prompt, and style reference settings.
+- **Token Indicator**: Control the advanced token counter in the status bar.
+
+[Open Settings](command:opencodego.openSettings)

--- a/resources/walkthrough/advanced-settings.nls.zh-cn.md
+++ b/resources/walkthrough/advanced-settings.nls.zh-cn.md
@@ -1,0 +1,11 @@
+## 高级设置
+
+通过扩展设置自定义你的 OpenCode Go 体验：
+
+- **模型预设**：通过命令面板在精确、均衡、创意或自定义温度/top_p 之间快速切换。
+- **Zen 免费模型**：启用 `opencodego.enableZenFreeModels` 将 OpenCode Zen 免费模型添加到选择器中。
+- **视觉代理**：配置用于为非视觉模型描述图片的视觉模型。
+- **Git 提交**：自定义提交消息语言、提示词和风格参考设置。
+- **Token 指示器**：控制状态栏中的高级 Token 计数器。
+
+[打开设置](command:opencodego.openSettings)

--- a/resources/walkthrough/set-api-key.md
+++ b/resources/walkthrough/set-api-key.md
@@ -1,0 +1,10 @@
+OpenCode Go for Copilot Chat uses your own OpenCode Go API key to make a variety of AI models available in the model picker.
+
+Paste it once, then update or remove it later from the Command Palette.
+
+- `Cmd/Ctrl + Shift + P`: Open the Command Palette
+- `OpenCodeGo: Set OpenCode Go API Key`: Set or update your API key
+- `OpenCodeGo: Generate Commit Message with OpenCodeGo`: Generate Git commit messages
+
+[Get an API Key](https://opencode.ai)
+[Set API Key](command:opencodego.setApiKey)

--- a/resources/walkthrough/set-api-key.nls.zh-cn.md
+++ b/resources/walkthrough/set-api-key.nls.zh-cn.md
@@ -1,0 +1,10 @@
+OpenCode Go for Copilot Chat 使用你自己的 OpenCode Go API 密钥，让丰富的 AI 模型出现在 Copilot 模型选择器中。
+
+只需粘贴一次，之后可通过命令面板更新或移除。
+
+- `Cmd/Ctrl + Shift + P`：打开命令面板
+- `OpenCodeGo: 设置 OpenCode Go API 密钥`：设置或更新 API 密钥
+- `OpenCodeGo: 使用 OpenCodeGo 生成提交消息`：生成 Git 提交消息
+
+[获取 API 密钥](https://opencode.ai)
+[设置 API 密钥](command:opencodego.setApiKey)

--- a/resources/walkthrough/show-models.md
+++ b/resources/walkthrough/show-models.md
@@ -1,0 +1,5 @@
+OpenCode Go models should appear in the Copilot model picker as soon as the extension is active. If an API key is not configured yet, they show a warning icon until you run `OpenCodeGo: Set OpenCode Go API Key`.
+
+If you do not see them right away, the model list may simply be long. Scroll down in the picker and look for models under the **OpenCode Go** family, or open the Language Models manager to check:
+
+[Open Language Models](command:workbench.action.chat.manage)

--- a/resources/walkthrough/show-models.nls.zh-cn.md
+++ b/resources/walkthrough/show-models.nls.zh-cn.md
@@ -1,0 +1,5 @@
+扩展激活后，OpenCode Go 模型应立即出现在 Copilot 模型选择器中。如果尚未配置 API 密钥，模型会显示警告图标，直到你运行「OpenCodeGo: 设置 OpenCode Go API 密钥」为止。
+
+如果没有立即看到，可能只是模型列表较长。在选取器中向下滚动，查找 **OpenCode Go** 分组下的模型，或打开语言模型管理器查看：
+
+[打开语言模型管理](command:workbench.action.chat.manage)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Command to open the OpenCode Go website to get an API key
     context.subscriptions.push(
         vscode.commands.registerCommand("opencodego.getApiKey", () => {
-            vscode.env.openExternal(vscode.Uri.parse("https://opencode.ai"));
+            vscode.env.openExternal(vscode.Uri.parse("https://opencode.ai/auth"));
         })
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,14 @@ import type { ModelPreset } from "./types";
 import { abortCommitGeneration, generateCommitMsg } from "./gitCommit/commitMessageGenerator";
 import { TokenizerManager } from "./tokenizer/tokenizerManager";
 
+// ---- Walkthrough / Welcome constants ----
+
+/** memento key tracking whether the welcome walkthrough has been shown. */
+const WELCOME_SHOWN_KEY = "opencodego.welcomeShown";
+
+/** Walkthrough contribution ID (publisher.extension#walkthroughId). */
+const WALKTHROUGH_ID = "OnesoftQwQ.opencode-go-copilot-provider#opencodeGoGettingStarted";
+
 export function activate(context: vscode.ExtensionContext) {
     // Initialize logger
     logger.init();
@@ -19,6 +27,12 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Register the OpenCode Go provider under the vendor id used in package.json
     vscode.lm.registerLanguageModelChatProvider("opencodego", provider);
+
+    // Helper: check if an API key is stored (without prompting)
+    const hasApiKey = async (): Promise<boolean> => {
+        const key = await context.secrets.get("opencodego.apiKey");
+        return !!key;
+    };
 
     // Management command to configure API key
     context.subscriptions.push(
@@ -41,6 +55,20 @@ export function activate(context: vscode.ExtensionContext) {
             }
             await context.secrets.store("opencodego.apiKey", apiKey.trim());
             vscode.window.showInformationMessage(l10n("OpenCode Go API key saved."));
+        })
+    );
+
+    // Command to open the OpenCode Go website to get an API key
+    context.subscriptions.push(
+        vscode.commands.registerCommand("opencodego.getApiKey", () => {
+            vscode.env.openExternal(vscode.Uri.parse("https://opencode.ai"));
+        })
+    );
+
+    // Command to open extension settings
+    context.subscriptions.push(
+        vscode.commands.registerCommand("opencodego.openSettings", () => {
+            vscode.commands.executeCommand("workbench.action.openSettings", "@ext:OnesoftQwQ.opencode-go-copilot-provider");
         })
     );
 
@@ -168,10 +196,36 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Show welcome walkthrough on first install (when no API key is configured)
+    showWelcomeIfNeeded(context);
+
     // Dispose logger on deactivate
     context.subscriptions.push({
         dispose: () => logger.dispose(),
     });
+}
+
+/**
+ * Show the welcome walkthrough on first activation if no API key is configured.
+ * Once shown (or if a key already exists) the flag is persisted so it won't
+ * reappear after subsequent reloads.
+ */
+async function showWelcomeIfNeeded(context: vscode.ExtensionContext): Promise<void> {
+    try {
+        if (context.globalState.get<boolean>(WELCOME_SHOWN_KEY)) {
+            return;
+        }
+        const apiKey = await context.secrets.get("opencodego.apiKey");
+        if (apiKey) {
+            // API key already set — no need to show welcome
+            await context.globalState.update(WELCOME_SHOWN_KEY, true);
+            return;
+        }
+        await vscode.commands.executeCommand("workbench.action.openWalkthrough", WALKTHROUGH_ID, false);
+        await context.globalState.update(WELCOME_SHOWN_KEY, true);
+    } catch (error) {
+        logger.warn("Failed to show welcome walkthrough", { error: String(error) });
+    }
 }
 
 export function deactivate() { }


### PR DESCRIPTION
### Changes

**1. Install Welcome Walkthrough**
- Added a 3-step VS Code Walkthrough (welcome guide) that auto-opens on first install when no API key is configured.
- Step 1: Guide users to set their OpenCode Go API key, with inline links to opencode.ai and the set-api-key command.
- Step 2: Guide users to open the Language Models manager to verify models appear.
- Step 3: Point users to advanced settings (model presets, Zen free models, vision proxy, etc.).
- Full zh-cn localization for all walkthrough pages.

**2. New Commands for Walkthrough Integration**
- `opencodego.getApiKey`: Opens the OpenCode AI website in the browser to obtain an API key.
- `opencodego.openSettings`: Opens VS Code settings filtered to the OpenCode Go extension.
- Both commands are registered in the walkthrough step descriptions as clickable links.

**3. Activation & Startup Detection**
- Added `onStartupFinished` activation event to ensure the extension activates early enough to detect first install.
- `showWelcomeIfNeeded()` checks `globalState` and secret storage; skips the walkthrough if already shown or if an API key already exists.

### Files Changed

| File | Change |
|------|--------|
| `package.json` | Added walkthroughs contribution, activationEvents, and 2 new commands |
| `package.nls.json` | Added walkthrough and new command localizations (English) |
| `package.nls.zh-cn.json` | Added walkthrough and new command localizations (zh-cn) |
| `resources/walkthrough/*.md` | 6 new walkthrough markdown files (3 steps &times; 2 languages) |
| `src/extension.ts` | Added showWelcomeIfNeeded(), 2 new command registrations, and constants |
| `AGENTS.md` | Updated to reflect new walkthrough functionality and file structure |