### PR TITLE
fix: DeepSeek invalid assistant message error & MiMo-V2.5 context length

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -53,11 +53,11 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     { baseId: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["high", "max"], contextLength: 1000000, maxTokens: 393216 },
     { baseId: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["high", "max"], contextLength: 1000000, maxTokens: 393216 },
 
-    // ── MiMo series ── 小米 MiMo 官方模型卡: 256K context (262144) ──
+    // ── MiMo series ── 小米 MiMo 官方模型卡: V2 256K (262144), V2.5 1M (1000000) ──
     { baseId: "mimo-v2-pro", displayName: "MiMo-V2-Pro", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
     { baseId: "mimo-v2-omni", displayName: "MiMo-V2-Omni", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
-    { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "always", contextLength: 262144, maxTokens: 32768 },
+    { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "always", contextLength: 1000000, maxTokens: 32768 },
+    { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "always", contextLength: 1000000, maxTokens: 32768 },
 
     // ── MiniMax series ── 官方文档: 204800 context (204.8K) ──
     // Note: minimax-m2.7 uses Anthropic API format (messages endpoint)

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -129,15 +129,17 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                     assistantMessage.content = joinedText;
                 }
 
-                if (modelConfig.includeReasoningInRequest) {
-                    assistantMessage.reasoning_content = joinedThinking || "Next step.";
+                if (modelConfig.includeReasoningInRequest && joinedThinking) {
+                    assistantMessage.reasoning_content = joinedThinking;
                 }
 
                 if (toolCalls.length > 0) {
                     assistantMessage.tool_calls = toolCalls;
                 }
 
-                if (assistantMessage.content || assistantMessage.reasoning_content || assistantMessage.tool_calls) {
+                // Must have content or tool_calls — reasoning_content alone is rejected
+                // by providers that require content/tool_calls to be set (e.g. DeepSeek).
+                if (assistantMessage.content || assistantMessage.tool_calls) {
                     out.push(assistantMessage);
                 }
             }

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -129,7 +129,10 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                     assistantMessage.content = joinedText;
                 }
 
-                if (modelConfig.includeReasoningInRequest && joinedThinking) {
+                // Always set reasoning_content when includeReasoningInRequest is true
+                // and reasoning parts exist — even if empty string, DeepSeek requires
+                // round-tripping for context continuity across conversation turns.
+                if (modelConfig.includeReasoningInRequest && reasoningParts.length > 0) {
                     assistantMessage.reasoning_content = joinedThinking;
                 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -648,9 +648,9 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 ...storedMessages,
                 {
                     role: "assistant" as const,
-                    content: null as string | null,
                     // DeepSeek requires reasoning_content when thinking mode is enabled,
-                    // even on tool call assistant messages
+                    // even on tool call assistant messages.
+                    // Note: content must be omitted, not null — DeepSeek rejects null content.
                     reasoning_content: "Calling describe_image tool to get a description of the user's attached image.",
                     tool_calls: [
                         {


### PR DESCRIPTION
### Changes

**1. Fix DeepSeek API rejecting assistant messages with only reasoning_content**
- `openaiApi.ts`: Don't inject fallback `reasoning_content` (`"Next step."`) when there's no actual thinking content. Tighten guard condition to require `content` or `tool_calls` — providers like DeepSeek reject messages with only `reasoning_content`.
- `provider.ts`: Remove `content: null` from second-round assistant message in `describe_image` interception, which DeepSeek also rejects.

**2. Fix MiMo-V2.5 model context length**
- MiMo-V2.5-Pro and MiMo-V2.5 context length corrected from 262144 (256K) to 1000000 (1M) per [official model card](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro). V2 models (MiMo-V2-Pro, MiMo-V2-Omni) remain at 256K.

### Files Changed

| File | Change |
|------|--------|
| `src/openai/openaiApi.ts` | Don't set fallback reasoning_content; require content or tool_calls in guard |
| `src/provider.ts` | Remove `content: null` from describe_image second-round assistant message |
| `src/models.ts` | Correct MiMo-V2.5 contextLength to 1000000 (1M) |

Closes #24