### PR TITLE
feat: add Qwen3.7 Max model definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ extension.vsix
 
 # VS Code
 .vscode/settings.json
+.vscode/
 
 # OS files
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 | 能力 | 说明 |
 |------|------|
 | **Chat 模型提供商** | 实现 `LanguageModelChatProvider` 接口，向 VS Code 注册为 `opencodego` 厂商 |
-| **多模型支持** | 内置 14 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（5 个） |
+| **多模型支持** | 内置 15 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（5 个） |
 | **OpenCode Zen 免费模型** | 通过设置开关启用，从 Zen API 获取模型列表并过滤出 5 个免费模型（Big Pickle、DeepSeek V4 Flash、MiniMax M2.5、Ring 2.6 1T、Nemotron 3 Super），以 `OpenCode Zen` 标识追加到模型选择器。支持内存缓存（5 分钟 TTL），API 不可用时静默降级 |
 | **双 API 模式** | 同时支持 **OpenAI 兼容格式** (`/chat/completions`) 和 **Anthropic 格式** (`/v1/messages`) |
 | **流式推理** | 支持 SSE (Server-Sent Events) 流式响应，实时输出文本和工具调用 |
@@ -60,7 +60,8 @@
 | DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `极高` | OpenAI |
 | MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `思考` | OpenAI |
 | MiniMax | `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `思考` | OpenAI (m2.7 使用 Anthropic) |
-| Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `思考` | OpenAI |
+| Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `思考` | Anthropic |
+| Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `思考` | Anthropic |
 
 #### OpenCode Zen 免费模型（可选）
 
@@ -397,7 +398,7 @@ src/
 |------|------|------|
 | `extension.ts` | ~210 | 扩展激活/停用，注册 Provider 和 6 条命令，首次安装欢迎页引导 |
 | `provider.ts` | ~670 | 实现 `LanguageModelChatProvider`，处理聊天请求全流程及图片代理第二轮处理 |
-| `models.ts` | ~218 | 14 个内置模型定义，模型配置查询（所有模型声明 `imageInput: true`） |
+| `models.ts` | ~219 | 15 个内置模型定义，模型配置查询（所有模型声明 `imageInput: true`） |
 | `types.ts` | ~95 | `OpenCodeGoModelItem`, `ModelPreset`, `ModelsResponse`, `RetryConfig` 等类型 |
 | `commonApi.ts` | ~458 | `CommonApi<TMessage,TRequestBody>` 抽象基类（图片存储、工具调用拦截） |
 | `provideModel.ts` | ~25 | 模型信息获取 |
@@ -488,7 +489,7 @@ src/
 | `apiMode` | `"openai" \| "anthropic"` (可选) | API 格式模式 |
 
 #### `const BUILT_IN_MODELS: BuiltInModelDef[]`
-14 个内置模型定义常量数组。
+15 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
 将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/思考` 或 `禁用思考/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。

--- a/src/models.ts
+++ b/src/models.ts
@@ -64,9 +64,11 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     { baseId: "minimax-m2.7", displayName: "MiniMax M2.7", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 204800, maxTokens: 32768 },
     { baseId: "minimax-m2.5", displayName: "MiniMax M2.5", vision: false, thinkingMode: "always", contextLength: 204800, maxTokens: 32768 },
 
-    // ── Qwen series ── 阿里云百炼: Qwen3.6-Plus 1M context, Qwen3.5-Plus 同代同规格 ──
-    { baseId: "qwen3.6-plus", displayName: "Qwen3.6 Plus", vision: true, thinkingMode: "switchable", contextLength: 1000000, maxTokens: 32768 },
-    { baseId: "qwen3.5-plus", displayName: "Qwen3.5 Plus", vision: true, thinkingMode: "switchable", contextLength: 1000000, maxTokens: 32768 },
+    // ── Qwen series ── 阿里云百炼: Qwen3.7-Max 1M context, Qwen3.6-Plus 1M context, Qwen3.5-Plus 同代同规格 ──
+    // Note: Qwen 系列使用 Anthropic API 格式 (messages endpoint)
+    { baseId: "qwen3.7-max", displayName: "Qwen3.7 Max", vision: false, thinkingMode: "switchable", apiMode: "anthropic", contextLength: 1000000, maxTokens: 65536 },
+    { baseId: "qwen3.6-plus", displayName: "Qwen3.6 Plus", vision: true, thinkingMode: "switchable", apiMode: "anthropic", contextLength: 1000000, maxTokens: 32768 },
+    { baseId: "qwen3.5-plus", displayName: "Qwen3.5 Plus", vision: true, thinkingMode: "switchable", apiMode: "anthropic", contextLength: 1000000, maxTokens: 32768 },
 ];
 
 /**


### PR DESCRIPTION
- Add qwen3.7-max to BUILT_IN_MODELS (1M context, 64K max output, switchable thinking)
- Set apiMode to 'anthropic' for all Qwen models per OpenCode Go docs
- Update AGENTS.md to reflect new model and correct API format