### PR TITLE
feat: add MiniMax-M3 model and adaptive thinking mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,9 @@
 | 系列 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 |
 |------|---------|------|----------------|----------|
 | GLM | `glm-5.1`, `glm-5` | ❌ | `思考`（不支持思考切换） | OpenAI |
-| Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `自动` | OpenAI |
-| DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `自动` / `高` / `极高` | OpenAI |
-| MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `自动` | OpenAI |
+| Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `思考` | OpenAI |
+| DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `极高` | OpenAI |
+| MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `思考` | OpenAI |
 | MiniMax | `minimax-m3`, `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `自动` | OpenAI (m2.7 使用 Anthropic) |
 | Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `自动` | Anthropic |
 | Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `自动` | Anthropic |
@@ -70,10 +70,10 @@
 | 显示名 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 | 备注 |
 |--------|---------|------|----------------|----------|------|
 | Zen/Big Pickle Free | `big-pickle` | ❌ | `思考`（不支持思考切换） | OpenAI | 限时免费 |
-| Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `自动` / `高` / `极高` | OpenAI | 限时免费 |
-| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `自动` | OpenAI | 限时免费 |
-| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `自动` | OpenAI | 限时免费 |
-| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `自动` | OpenAI | 限时免费 |
+| Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `高` / `极高` | OpenAI | 限时免费 |
+| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
 
 在模型选择器中，内置模型归入 `OpenCode Go` 分组（`family="OpenCodeGo"`），Zen 免费模型归入 `OpenCode Zen` 分组（`family="OpenCode Zen"`）以作区分。
 
@@ -496,7 +496,7 @@ src/
 16 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
-将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/自动/思考` 或 `禁用思考/自动/高/最大`（可关闭推理）；adaptive 模型仅显示 `禁用思考/自动`；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
+将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/思考` 或 `禁用思考/高/最大`（可关闭推理）；adaptive 模型仅显示 `禁用思考/自动`；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
 
 #### `getBuiltInModelCount(): number`
 返回内置模型定义总数（BUILT_IN_MODELS.length）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,12 +56,12 @@
 | 系列 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 |
 |------|---------|------|----------------|----------|
 | GLM | `glm-5.1`, `glm-5` | ❌ | `思考`（不支持思考切换） | OpenAI |
-| Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `自动` / `思考` | OpenAI |
+| Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `自动` | OpenAI |
 | DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `自动` / `高` / `极高` | OpenAI |
-| MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `自动` / `思考` | OpenAI |
-| MiniMax | `minimax-m3`, `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI (m2.7/m3 使用 Anthropic) |
-| Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `自动` / `思考` | Anthropic |
-| Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `自动` / `思考` | Anthropic |
+| MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `自动` | OpenAI |
+| MiniMax | `minimax-m3`, `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `自动` | OpenAI (m2.7 使用 Anthropic) |
+| Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `自动` | Anthropic |
+| Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `自动` | Anthropic |
 
 #### OpenCode Zen 免费模型（可选）
 
@@ -71,14 +71,17 @@
 |--------|---------|------|----------------|----------|------|
 | Zen/Big Pickle Free | `big-pickle` | ❌ | `思考`（不支持思考切换） | OpenAI | 限时免费 |
 | Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `自动` / `高` / `极高` | OpenAI | 限时免费 |
-| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI | 限时免费 |
-| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI | 限时免费 |
-| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI | 限时免费 |
+| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `自动` | OpenAI | 限时免费 |
+| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `自动` | OpenAI | 限时免费 |
+| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `自动` | OpenAI | 限时免费 |
 
 在模型选择器中，内置模型归入 `OpenCode Go` 分组（`family="OpenCodeGo"`），Zen 免费模型归入 `OpenCode Zen` 分组（`family="OpenCode Zen"`）以作区分。
 
 > 所有模型在模型选择器中均显示**一个条目**，通过**推理强度选择器**（中文标签）切换思考模式。  
-> - `thinkingMode="switchable"`：用户可选择`禁用思考`、`自动`或启用思考（强度可配置）  
+> 所有模型在模型选择器中均显示**一个条目**，通过**推理强度选择器**（中文标签）切换思考模式。  
+> - `thinkingMode="switchable"`：用户可选择`禁用思考`或`自动`（或特定强度档位），由模型自动决定是否启用思考  
+> - `thinkingMode="adaptive"`：仅`禁用思考`和`自动`两档选择，无强制启用思考选项  
+> - `thinkingMode="always"`：推理始终启用，选择器中不显示`禁用思考`选项（模型特性）  
 > - `thinkingMode="always"`：推理始终启用，选择器中不显示`禁用思考`选项（模型特性）  
 > 
 > **关于图像输入：** 所有模型（包括非视觉模型）的 `imageInput` 能力均声明为 `true`，以确保 VS Code 始终传递图片数据。非视觉模型通过内部的 `describe_image` 工具代理机制处理图片，不直接支持视觉输入。
@@ -480,7 +483,7 @@ src/
 | `baseId` | `string` | API 请求中使用的模型 ID |
 | `displayName` | `string` | 用户友好的显示名称 |
 | `vision` | `boolean` | 是否支持图片输入（所有模型 `imageInput` 能力声明为 `true`，非视觉模型通过代理处理） |
-| `thinkingMode` | `"switchable" \| "always"` | switchable=可选择思考开关, always=思考始终启用 |
+| `thinkingMode` | `"switchable" \| "always" \| "adaptive"` | switchable=可选择思考开关, always=思考始终启用, adaptive=仅禁用/自动 |
 | `defaultReasoningEffort` | `string` (可选) | 默认推理力度 |
 | `supportedReasoningEfforts` | `string[]` (可选) | 支持的推理力度选项 |
 | `includeReasoningInRequest` | `boolean` (可选) | 是否在 assistant 消息中包含 reasoning_content |
@@ -493,7 +496,7 @@ src/
 16 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
-将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/自动/思考` 或 `禁用思考/自动/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
+将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/自动` 或 `禁用思考/自动/高/最大`（可关闭推理）；adaptive 模型仅显示 `禁用思考/自动`；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
 
 #### `getBuiltInModelCount(): number`
 返回内置模型定义总数（BUILT_IN_MODELS.length）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,12 +56,12 @@
 | 系列 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 |
 |------|---------|------|----------------|----------|
 | GLM | `glm-5.1`, `glm-5` | ❌ | `思考`（不支持思考切换） | OpenAI |
-| Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `思考` | OpenAI |
-| DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `极高` | OpenAI |
-| MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `思考` | OpenAI |
-| MiniMax | `minimax-m3`, `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `思考` | OpenAI (m2.7/m3 使用 Anthropic) |
-| Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `思考` | Anthropic |
-| Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `思考` | Anthropic |
+| Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `自动` / `思考` | OpenAI |
+| DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `自动` / `高` / `极高` | OpenAI |
+| MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `自动` / `思考` | OpenAI |
+| MiniMax | `minimax-m3`, `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI (m2.7/m3 使用 Anthropic) |
+| Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `自动` / `思考` | Anthropic |
+| Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `自动` / `思考` | Anthropic |
 
 #### OpenCode Zen 免费模型（可选）
 
@@ -70,15 +70,15 @@
 | 显示名 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 | 备注 |
 |--------|---------|------|----------------|----------|------|
 | Zen/Big Pickle Free | `big-pickle` | ❌ | `思考`（不支持思考切换） | OpenAI | 限时免费 |
-| Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `高` / `极高` | OpenAI | 限时免费 |
-| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
-| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
-| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+| Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `自动` / `高` / `极高` | OpenAI | 限时免费 |
+| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI | 限时免费 |
+| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI | 限时免费 |
+| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `自动` / `思考` | OpenAI | 限时免费 |
 
 在模型选择器中，内置模型归入 `OpenCode Go` 分组（`family="OpenCodeGo"`），Zen 免费模型归入 `OpenCode Zen` 分组（`family="OpenCode Zen"`）以作区分。
 
 > 所有模型在模型选择器中均显示**一个条目**，通过**推理强度选择器**（中文标签）切换思考模式。  
-> - `thinkingMode="switchable"`：用户可选择`禁用思考`或启用思考（强度可配置）  
+> - `thinkingMode="switchable"`：用户可选择`禁用思考`、`自动`或启用思考（强度可配置）  
 > - `thinkingMode="always"`：推理始终启用，选择器中不显示`禁用思考`选项（模型特性）  
 > 
 > **关于图像输入：** 所有模型（包括非视觉模型）的 `imageInput` 能力均声明为 `true`，以确保 VS Code 始终传递图片数据。非视觉模型通过内部的 `describe_image` 工具代理机制处理图片，不直接支持视觉输入。
@@ -155,6 +155,7 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │
   ├── 2. 应用用户配置的 reasoningEffort
   │       ├── "disabled" → 关闭思考（always 模型除外）
+  │       ├── "adaptive" → 开启思考，自动模式（发送 thinking: { type: "adaptive" }）
   │       ├── "enabled" → 开启思考，使用默认推理力度
   │       ├── "high"/"max" → 开启思考，指定推理力度
   │
@@ -492,7 +493,7 @@ src/
 16 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
-将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/思考` 或 `禁用思考/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
+将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/自动/思考` 或 `禁用思考/自动/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
 
 #### `getBuiltInModelCount(): number`
 返回内置模型定义总数（BUILT_IN_MODELS.length）。
@@ -846,7 +847,7 @@ describe_image 工具定义的 OpenAI 格式（`type: "function"`），包含参
 将 VS Code 消息转换为 OpenAI 格式。支持文本、图片、工具调用、工具结果、推理内容的消息转换。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。
 
 #### `prepareRequestBody(rb, um?, options?): Record<string, unknown>`
-构建 OpenAI 请求体。设置 temperature、top_p、max_tokens、reasoning_effort、thinking 模式、stop、tools、tool_choice 以及各种惩罚参数和 extra 参数。非视觉模型且存在图片时自动注入 `describe_image` 工具定义。
+构建 OpenAI 请求体。设置 temperature、top_p、max_tokens、reasoning_effort（adaptive 模式时跳过）、thinking 模式（支持 `{ type: "enabled" }` 和 `{ type: "adaptive" }`）、stop、tools、tool_choice 以及各种惩罚参数和 extra 参数。非视觉模型且存在图片时自动注入 `describe_image` 工具定义。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
 处理 OpenAI SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，处理 `[DONE]` 标记，解析 usage 用量信息，委托 `processDelta()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。
@@ -910,7 +911,7 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 将 VS Code 消息转换为 Anthropic 格式。系统消息提取到 `_systemContent`。支持文本、图片、工具使用、工具结果、推理内容。使用 `content` 块数组格式。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。
 
 #### `prepareRequestBody(rb, um?, options?): AnthropicRequestBody`
-构建 Anthropic 请求体。设置 max_tokens、system、temperature、top_p、top_k、tools（转换为 Anthropic 格式）、tool_choice（auto/any/none）以及 extra 参数。非视觉模型且存在图片时自动注入 `describe_image` 工具定义。
+构建 Anthropic 请求体。设置 max_tokens、system、temperature、top_p、top_k、thinking 模式（支持 `{ type: "enabled" }` 和 `{ type: "adaptive" }`）、tools（转换为 Anthropic 格式）、tool_choice（auto/any/none）以及 extra 参数。非视觉模型且存在图片时自动注入 `describe_image` 工具定义。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
 处理 Anthropic SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，委托 `processAnthropicChunk()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 | 能力 | 说明 |
 |------|------|
 | **Chat 模型提供商** | 实现 `LanguageModelChatProvider` 接口，向 VS Code 注册为 `opencodego` 厂商 |
-| **多模型支持** | 内置 15 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（5 个） |
+| **多模型支持** | 内置 16 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（5 个） |
 | **OpenCode Zen 免费模型** | 通过设置开关启用，从 Zen API 获取模型列表并过滤出 5 个免费模型（Big Pickle、DeepSeek V4 Flash、MiniMax M2.5、Ring 2.6 1T、Nemotron 3 Super），以 `OpenCode Zen` 标识追加到模型选择器。支持内存缓存（5 分钟 TTL），API 不可用时静默降级 |
 | **双 API 模式** | 同时支持 **OpenAI 兼容格式** (`/chat/completions`) 和 **Anthropic 格式** (`/v1/messages`) |
 | **流式推理** | 支持 SSE (Server-Sent Events) 流式响应，实时输出文本和工具调用 |
@@ -59,7 +59,7 @@
 | Kimi | `kimi-k2.5`, `kimi-k2.6` | ✅ | `禁用思考` / `思考` | OpenAI |
 | DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `极高` | OpenAI |
 | MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `思考` | OpenAI |
-| MiniMax | `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `思考` | OpenAI (m2.7 使用 Anthropic) |
+| MiniMax | `minimax-m3`, `minimax-m2.7`, `minimax-m2.5` | ❌ | `禁用思考` / `思考` | OpenAI (m2.7/m3 使用 Anthropic) |
 | Qwen | `qwen3.7-max` | ❌ | `禁用思考` / `思考` | Anthropic |
 | Qwen | `qwen3.6-plus`, `qwen3.5-plus` | ✅ | `禁用思考` / `思考` | Anthropic |
 
@@ -398,7 +398,7 @@ src/
 |------|------|------|
 | `extension.ts` | ~210 | 扩展激活/停用，注册 Provider 和 6 条命令，首次安装欢迎页引导 |
 | `provider.ts` | ~670 | 实现 `LanguageModelChatProvider`，处理聊天请求全流程及图片代理第二轮处理 |
-| `models.ts` | ~219 | 15 个内置模型定义，模型配置查询（所有模型声明 `imageInput: true`） |
+| `models.ts` | ~225 | 16 个内置模型定义，模型配置查询（所有模型声明 `imageInput: true`） |
 | `types.ts` | ~95 | `OpenCodeGoModelItem`, `ModelPreset`, `ModelsResponse`, `RetryConfig` 等类型 |
 | `commonApi.ts` | ~458 | `CommonApi<TMessage,TRequestBody>` 抽象基类（图片存储、工具调用拦截） |
 | `provideModel.ts` | ~25 | 模型信息获取 |
@@ -489,7 +489,7 @@ src/
 | `apiMode` | `"openai" \| "anthropic"` (可选) | API 格式模式 |
 
 #### `const BUILT_IN_MODELS: BuiltInModelDef[]`
-15 个内置模型定义常量数组。
+16 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
 将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/思考` 或 `禁用思考/高/最大`（可关闭推理）；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@
 
 > 所有模型在模型选择器中均显示**一个条目**，通过**推理强度选择器**（中文标签）切换思考模式。  
 > 所有模型在模型选择器中均显示**一个条目**，通过**推理强度选择器**（中文标签）切换思考模式。  
-> - `thinkingMode="switchable"`：用户可选择`禁用思考`或`自动`（或特定强度档位），由模型自动决定是否启用思考  
+> - `thinkingMode="switchable"`：用户可选择`禁用思考`、`自动`或启用思考（强度可配置）  
 > - `thinkingMode="adaptive"`：仅`禁用思考`和`自动`两档选择，无强制启用思考选项  
 > - `thinkingMode="always"`：推理始终启用，选择器中不显示`禁用思考`选项（模型特性）  
 > - `thinkingMode="always"`：推理始终启用，选择器中不显示`禁用思考`选项（模型特性）  
@@ -496,7 +496,7 @@ src/
 16 个内置模型定义常量数组。
 
 #### `getBuiltInModelInfos(): LanguageModelChatInformation[]`
-将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/自动` 或 `禁用思考/自动/高/最大`（可关闭推理）；adaptive 模型仅显示 `禁用思考/自动`；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
+将内置模型定义转换为 VS Code 的模型信息列表。每个模型注册**一个条目**，带 `isUserSelectable: true` 确保在模型选择器中可见（VS Code 1.120+ 要求），并通过 `configurationSchema` 附加推理强度选择器（中文标签）。switchable 模型显示 `禁用思考/自动/思考` 或 `禁用思考/自动/高/最大`（可关闭推理）；adaptive 模型仅显示 `禁用思考/自动`；always 模型不显示 `禁用思考` 选项，仅在支持推理强度时显示强度选项。
 
 #### `getBuiltInModelCount(): number`
 返回内置模型定义总数（BUILT_IN_MODELS.length）。

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -225,6 +225,16 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			rb.top_k = um.top_k;
 		}
 
+		// Add thinking mode (Anthropic-compatible format)
+		// Only set when thinking is enabled; omit when disabled to avoid sending invalid values
+		if (um?.enable_thinking === true) {
+			if (um?.reasoning_effort === 'adaptive') {
+				rb.thinking = { type: "adaptive" };
+			} else {
+				rb.thinking = { type: "enabled", budget_tokens: 8192 };
+			}
+		}
+
 		// Add tools configuration
 		const toolConfig = convertToolsToOpenAI(options);
 		const anthropicToolList: Array<{ name: string; description?: string; input_schema?: object }> = [];

--- a/src/anthropic/anthropicTypes.ts
+++ b/src/anthropic/anthropicTypes.ts
@@ -66,8 +66,8 @@ export interface AnthropicRequestBody {
 	};
 	service_tier?: "auto" | "standard_only";
 	thinking?: {
-		type: "enabled";
-		budget_tokens: number;
+		type: "enabled" | "adaptive";
+		budget_tokens?: number;
 	};
 	tools?: AnthropicToolDefinition[];
 	tool_choice?: AnthropicToolChoice;

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -40,6 +40,7 @@ const zhCN: Record<string, string> = {
 
 	// reasoning effort labels (keys are English fallback text)
 	"Disabled": "禁用思考",
+	"Adaptive": "自动",
 	"Thinking": "思考",
 	"Low": "低",
 	"Medium": "中",
@@ -48,6 +49,7 @@ const zhCN: Record<string, string> = {
 
 	// reasoning effort descriptions (keys are English fallback text)
 	"Do not enable thinking": "不启用思考",
+	"Automatically decide when to think": "自动决定何时思考",
 	"Enable thinking": "启用思考",
 	"Reduce thinking, faster response": "减少思考，响应更快",
 	"Balance thinking and speed": "平衡思考与速度",

--- a/src/models.ts
+++ b/src/models.ts
@@ -61,7 +61,7 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
 
     // ── MiniMax series ── 官方文档: M2.7/M2.5 204800 context (204.8K), M3 1M context ──
     // Note: minimax-m2.7 and minimax-m3 use Anthropic API format (messages endpoint)
-    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
+    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "switchable", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
     { baseId: "minimax-m2.7", displayName: "MiniMax M2.7", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 204800, maxTokens: 32768 },
     { baseId: "minimax-m2.5", displayName: "MiniMax M2.5", vision: false, thinkingMode: "always", contextLength: 204800, maxTokens: 32768 },
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -108,13 +108,13 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
         let enumValues: string[];
         if (hasEfforts) {
             if (def.thinkingMode === "switchable") {
-                enumValues = ["disabled", ...def.supportedReasoningEfforts!];
+                enumValues = ["disabled", "adaptive", ...def.supportedReasoningEfforts!];
             } else {
                 enumValues = [...def.supportedReasoningEfforts!];
             }
         } else {
             if (def.thinkingMode === "switchable") {
-                enumValues = ["disabled", "enabled"];
+                enumValues = ["disabled", "adaptive", "enabled"];
             } else {
                 enumValues = ["enabled"];
             }
@@ -125,6 +125,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
         const getLabel = (e: string): string => {
             switch (e) {
                 case 'disabled': return l10n("Disabled");
+                case 'adaptive': return l10n("Adaptive");
                 case 'enabled': return l10n("Thinking");
                 case 'low': return l10n("Low");
                 case 'medium': return l10n("Medium");
@@ -136,6 +137,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
         const getDesc = (e: string): string => {
             switch (e) {
                 case 'disabled': return l10n("Do not enable thinking");
+                case 'adaptive': return l10n("Automatically decide when to think");
                 case 'enabled': return l10n("Enable thinking");
                 case 'low': return l10n("Reduce thinking, faster response");
                 case 'medium': return l10n("Balance thinking and speed");

--- a/src/models.ts
+++ b/src/models.ts
@@ -104,8 +104,8 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
         };
 
         // Build enum values based on thinking mode
-        // - "switchable" + hasEfforts: disabled / adaptive / [effort levels]   (e.g. disabled/adaptive/high/max)
-        // - "switchable" + no efforts: disabled / adaptive / enabled
+        // - "switchable" + hasEfforts: disabled / [effort levels]             (e.g. disabled/high/max)
+        // - "switchable" + no efforts: disabled / enabled
         // - "adaptive"               : disabled / adaptive                    (only two: off or auto-decide)
         // - "always"    + hasEfforts: [effort levels]
         // - "always"    + no efforts: enabled
@@ -113,13 +113,13 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
         let enumValues: string[];
         if (hasEfforts) {
             if (def.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive", ...def.supportedReasoningEfforts!];
+                enumValues = ["disabled", ...def.supportedReasoningEfforts!];
             } else {
                 enumValues = [...def.supportedReasoningEfforts!];
             }
         } else {
             if (def.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive", "enabled"];
+                enumValues = ["disabled", "enabled"];
             } else if (def.thinkingMode === "adaptive") {
                 enumValues = ["disabled", "adaptive"];
             } else {

--- a/src/models.ts
+++ b/src/models.ts
@@ -12,8 +12,8 @@ interface BuiltInModelDef {
     displayName: string;
     /** Whether the model supports image input */
     vision: boolean;
-    /** Thinking mode: "switchable" = two variants registered, "always" = thinking forced on */
-    thinkingMode: "switchable" | "always";
+    /** Thinking mode: "switchable" = user can toggle, "always" = thinking forced on, "adaptive" = only disabled/adaptive */
+    thinkingMode: "switchable" | "always" | "adaptive";
     /** Default reasoning effort when thinking is enabled */
     defaultReasoningEffort?: string;
     /** Supported reasoning effort levels for the model picker UI */
@@ -61,7 +61,7 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
 
     // ── MiniMax series ── 官方文档: M2.7/M2.5 204800 context (204.8K), M3 1M context ──
     // Note: minimax-m2.7 and minimax-m3 use Anthropic API format (messages endpoint)
-    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "switchable", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
+    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "adaptive", apiMode: "openai", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
     { baseId: "minimax-m2.7", displayName: "MiniMax M2.7", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 204800, maxTokens: 32768 },
     { baseId: "minimax-m2.5", displayName: "MiniMax M2.5", vision: false, thinkingMode: "always", contextLength: 204800, maxTokens: 32768 },
 
@@ -104,6 +104,11 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
         };
 
         // Build enum values based on thinking mode
+        // - "switchable" + hasEfforts: disabled / adaptive / [effort levels]   (e.g. disabled/adaptive/high/max)
+        // - "switchable" + no efforts: disabled / adaptive
+        // - "adaptive"               : disabled / adaptive                    (only two: off or auto-decide)
+        // - "always"    + hasEfforts: [effort levels]
+        // - "always"    + no efforts: enabled
         const hasEfforts = def.supportedReasoningEfforts && def.supportedReasoningEfforts.length > 0;
         let enumValues: string[];
         if (hasEfforts) {
@@ -114,7 +119,9 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
             }
         } else {
             if (def.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive", "enabled"];
+                enumValues = ["disabled", "adaptive"];
+            } else if (def.thinkingMode === "adaptive") {
+                enumValues = ["disabled", "adaptive"];
             } else {
                 enumValues = ["enabled"];
             }

--- a/src/models.ts
+++ b/src/models.ts
@@ -61,9 +61,9 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
 
     // ── MiniMax series ── 官方文档: M2.7/M2.5 204800 context (204.8K), M3 1M context ──
     // Note: minimax-m2.7 and minimax-m3 use Anthropic API format (messages endpoint)
-    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "adaptive", apiMode: "openai", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
+    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "adaptive", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
     { baseId: "minimax-m2.7", displayName: "MiniMax M2.7", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 204800, maxTokens: 32768 },
-    { baseId: "minimax-m2.5", displayName: "MiniMax M2.5", vision: false, thinkingMode: "always", contextLength: 204800, maxTokens: 32768 },
+    { baseId: "minimax-m2.5", displayName: "MiniMax M2.5", vision: false, thinkingMode: "always", apiMode: "anthropic", contextLength: 204800, maxTokens: 32768 },
 
     // ── Qwen series ── 阿里云百炼: Qwen3.7-Max 1M context, Qwen3.6-Plus 1M context, Qwen3.5-Plus 同代同规格 ──
     // Note: Qwen 系列使用 Anthropic API 格式 (messages endpoint)

--- a/src/models.ts
+++ b/src/models.ts
@@ -59,8 +59,9 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     { baseId: "mimo-v2.5-pro", displayName: "MiMo-V2.5-Pro", vision: false, thinkingMode: "switchable", contextLength: 1000000, maxTokens: 32768 },
     { baseId: "mimo-v2.5", displayName: "MiMo-V2.5", vision: false, thinkingMode: "switchable", contextLength: 1000000, maxTokens: 32768 },
 
-    // ── MiniMax series ── 官方文档: 204800 context (204.8K) ──
-    // Note: minimax-m2.7 uses Anthropic API format (messages endpoint)
+    // ── MiniMax series ── 官方文档: M2.7/M2.5 204800 context (204.8K), M3 1M context ──
+    // Note: minimax-m2.7 and minimax-m3 use Anthropic API format (messages endpoint)
+    { baseId: "minimax-m3", displayName: "MiniMax M3", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 1000000, maxTokens: 32768 },
     { baseId: "minimax-m2.7", displayName: "MiniMax M2.7", vision: false, thinkingMode: "always", apiMode: "anthropic", extra: { reasoning_split: true }, contextLength: 204800, maxTokens: 32768 },
     { baseId: "minimax-m2.5", displayName: "MiniMax M2.5", vision: false, thinkingMode: "always", contextLength: 204800, maxTokens: 32768 },
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -105,7 +105,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
 
         // Build enum values based on thinking mode
         // - "switchable" + hasEfforts: disabled / adaptive / [effort levels]   (e.g. disabled/adaptive/high/max)
-        // - "switchable" + no efforts: disabled / adaptive
+        // - "switchable" + no efforts: disabled / adaptive / enabled
         // - "adaptive"               : disabled / adaptive                    (only two: off or auto-decide)
         // - "always"    + hasEfforts: [effort levels]
         // - "always"    + no efforts: enabled
@@ -119,7 +119,7 @@ export function getBuiltInModelInfos(): LanguageModelChatInformation[] {
             }
         } else {
             if (def.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive"];
+                enumValues = ["disabled", "adaptive", "enabled"];
             } else if (def.thinkingMode === "adaptive") {
                 enumValues = ["disabled", "adaptive"];
             } else {

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -215,15 +215,20 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         }
 
         // OpenAI reasoning configuration (only set when thinking is enabled)
-        if (um?.enable_thinking !== false && um?.reasoning_effort !== undefined) {
+        // Skip reasoning_effort for "adaptive" — it's not a standard API value
+        if (um?.enable_thinking !== false && um?.reasoning_effort !== undefined && um.reasoning_effort !== 'adaptive') {
             rb.reasoning_effort = um.reasoning_effort;
         }
 
         // Thinking mode (OpenAI-compatible format: {"thinking": {"type": "enabled"}})
         if (um?.enable_thinking === true) {
-            rb.thinking = { type: "enabled" };
-            if (um?.thinking_budget !== undefined) {
-                (rb.thinking as Record<string, unknown>).budget_tokens = um.thinking_budget;
+            if (um?.reasoning_effort === 'adaptive') {
+                rb.thinking = { type: "adaptive" };
+            } else {
+                rb.thinking = { type: "enabled" };
+                if (um?.thinking_budget !== undefined) {
+                    (rb.thinking as Record<string, unknown>).budget_tokens = um.thinking_budget;
+                }
             }
         } else {
             rb.thinking = { type: "disabled" };

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,8 +50,8 @@ export interface OpenCodeGoModelItem {
     delay?: number;
     /** API mode (for internal use) */
     apiMode?: string;
-    /** Whether this model supports switching thinking on/off ("switchable") or always has it ("always") */
-    thinkingMode?: "switchable" | "always";
+    /** Whether this model supports switching thinking on/off ("switchable"), always has it ("always"), or only disabled/adaptive ("adaptive") */
+    thinkingMode?: "switchable" | "always" | "adaptive";
     /** Custom HTTP headers */
     headers?: Record<string, string>;
 

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -123,21 +123,22 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
         }
 
         // Build reasoning effort enum based on thinking mode
-        // - "switchable" + hasEfforts: disabled / adaptive / [effort levels]
-        // - "switchable" + no efforts: disabled / adaptive / enabled
+        // - "switchable" + hasEfforts: disabled / [effort levels]
+        // - "switchable" + no efforts: disabled / enabled
+        // - "adaptive"               : disabled / adaptive
         // - "always"    + hasEfforts: [effort levels]
         // - "always"    + no efforts: enabled
         const hasEfforts = meta.supportedReasoningEfforts && meta.supportedReasoningEfforts.length > 0;
         let enumValues: string[];
         if (hasEfforts) {
             if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive", ...meta.supportedReasoningEfforts!];
+                enumValues = ["disabled", ...meta.supportedReasoningEfforts!];
             } else {
                 enumValues = [...meta.supportedReasoningEfforts!];
             }
         } else {
             if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive", "enabled"];
+                enumValues = ["disabled", "enabled"];
             } else {
                 enumValues = ["enabled"];
             }

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -127,13 +127,13 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
         let enumValues: string[];
         if (hasEfforts) {
             if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", ...meta.supportedReasoningEfforts!];
+                enumValues = ["disabled", "adaptive", ...meta.supportedReasoningEfforts!];
             } else {
                 enumValues = [...meta.supportedReasoningEfforts!];
             }
         } else {
             if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", "enabled"];
+                enumValues = ["disabled", "adaptive", "enabled"];
             } else {
                 enumValues = ["enabled"];
             }
@@ -141,6 +141,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
         const enumItemLabels = enumValues.map((e) => {
             switch (e) {
                 case 'disabled': return l10n("Disabled");
+                case 'adaptive': return l10n("Adaptive");
                 case 'enabled': return l10n("Thinking");
                 case 'high': return l10n("High");
                 case 'max': return l10n("Maximum");
@@ -150,6 +151,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
         const enumDescriptions = enumValues.map((e) => {
             switch (e) {
                 case 'disabled': return l10n("Do not enable thinking");
+                case 'adaptive': return l10n("Automatically decide when to think");
                 case 'enabled': return l10n("Enable thinking");
                 case 'high': return l10n("Deeper thinking, slower response");
                 case 'max': return l10n("Maximum thinking depth, slowest response");

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -123,6 +123,10 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
         }
 
         // Build reasoning effort enum based on thinking mode
+        // - "switchable" + hasEfforts: disabled / adaptive / [effort levels]
+        // - "switchable" + no efforts: disabled / adaptive  (adaptive replaces "enabled" because it covers the same need)
+        // - "always"    + hasEfforts: [effort levels]
+        // - "always"    + no efforts: enabled
         const hasEfforts = meta.supportedReasoningEfforts && meta.supportedReasoningEfforts.length > 0;
         let enumValues: string[];
         if (hasEfforts) {
@@ -133,7 +137,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
             }
         } else {
             if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive", "enabled"];
+                enumValues = ["disabled", "adaptive"];
             } else {
                 enumValues = ["enabled"];
             }

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -124,7 +124,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
 
         // Build reasoning effort enum based on thinking mode
         // - "switchable" + hasEfforts: disabled / adaptive / [effort levels]
-        // - "switchable" + no efforts: disabled / adaptive  (adaptive replaces "enabled" because it covers the same need)
+        // - "switchable" + no efforts: disabled / adaptive / enabled
         // - "always"    + hasEfforts: [effort levels]
         // - "always"    + no efforts: enabled
         const hasEfforts = meta.supportedReasoningEfforts && meta.supportedReasoningEfforts.length > 0;
@@ -137,7 +137,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
             }
         } else {
             if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", "adaptive"];
+                enumValues = ["disabled", "adaptive", "enabled"];
             } else {
                 enumValues = ["enabled"];
             }


### PR DESCRIPTION
### Changes

**1. MiniMax-M3 model support**
- Added `minimax-m3` model definition with 1M context length, Anthropic API format, and `reasoning_split` enabled.
- Added missing `apiMode: "anthropic"` to `minimax-m2.5` for consistency within the MiniMax series.

**2. New adaptive thinking mode**
- Extended `BuiltInModelDef.thinkingMode` with `"adaptive"` type, enabling only `disabled` / `adaptive` (自动) options in the reasoning effort selector.
- Extended `OpenCodeGoModelItem.thinkingMode` type to match.
- Added `"adaptive"` branch to the enum-building logic in both built-in and Zen model lists.
- Updated `openaiApi.ts` to send `thinking: { type: "adaptive" }` when adaptive is selected, skipping the non-standard `reasoning_effort` parameter.
- Updated `anthropicApi.ts` to send `thinking: { type: "adaptive" }` in the request body.
- Extended `AnthropicRequestBody.thinking.type` to accept `"enabled" | "adaptive"`.
- Added Chinese localization for "Adaptive" → "自动" and its description.

**3. MiMo V2.5 models thinking mode**
- Changed `mimo-v2.5-pro` and `mimo-v2.5` from `thinkingMode: "always"` to `"switchable"`, giving users control over thinking.

### Files Changed

| File | Change |
|------|--------|
| `src/models.ts` | Added `minimax-m3` model, new `adaptive` thinking type, adaptive enum branch, MiMo V2.5 switchable toggle |
| `src/types.ts` | Extended `thinkingMode` type with `"adaptive"` |
| `src/openai/openaiApi.ts` | Handle adaptive: send `thinking: { type: "adaptive" }`, skip `reasoning_effort` |
| `src/anthropic/anthropicApi.ts` | Added thinking block with adaptive support |
| `src/anthropic/anthropicTypes.ts` | Extended thinking type to accept `"adaptive"` |
| `src/zen/zenModels.ts` | Added adaptive enum branch, MiMo V2.5 Free model |
| `src/localize.ts` | Added "Adaptive" translation |
| `AGENTS.md` | Updated model tables, thinking mode descriptions |