### PR TITLE
fix: detect tool result images and stabilize the ask_image vision proxy pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,7 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   ├── 1. convertMessages()
   │      模型 vision=false，有 image → 替换为 "[The user sent an image (imageIndex=N)... I MUST call the ask_image tool...]"
   │      原图数据存入 CommonApi.storedImages 静态池
+  │      同时递归扫描 tool result 内嵌的图片一并存入
   │      记录 _hasStoredImages = true，保存 _originalApiMessages
   │
   ├── 2. prepareRequestBody()
@@ -847,7 +848,7 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 构造函数，传入模型 ID。
 
 #### `convertMessages(messages, modelConfig): OpenAIChatMessage[]`
-将 VS Code 消息转换为 OpenAI 格式。支持文本、图片、工具调用、工具结果、推理内容的消息转换。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。
+将 VS Code 消息转换为 OpenAI 格式。支持文本、图片、工具调用、工具结果、推理内容的消息转换。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。同时递归扫描 `LanguageModelToolResultPart.content` 中的图片一并存入（确保通过工具返回的图片也能被 `ask_image` 代理识别）。
 
 #### `prepareRequestBody(rb, um?, options?): Record<string, unknown>`
 构建 OpenAI 请求体。设置 temperature、top_p、max_tokens、reasoning_effort（adaptive 模式时跳过）、thinking 模式（支持 `{ type: "enabled" }` 和 `{ type: "adaptive" }`）、stop、tools、tool_choice 以及各种惩罚参数和 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。
@@ -911,7 +912,7 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 构造函数，传入模型 ID。
 
 #### `convertMessages(messages, modelConfig): AnthropicMessage[]`
-将 VS Code 消息转换为 Anthropic 格式。系统消息提取到 `_systemContent`。支持文本、图片、工具使用、工具结果、推理内容。使用 `content` 块数组格式。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。
+将 VS Code 消息转换为 Anthropic 格式。系统消息提取到 `_systemContent`。支持文本、图片、工具使用、工具结果、推理内容。使用 `content` 块数组格式。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。同时递归扫描 `AnthropicToolResultBlock.content` 中的图片一并存入（确保通过工具返回的图片也能被 `ask_image` 代理识别）。
 
 #### `prepareRequestBody(rb, um?, options?): AnthropicRequestBody`
 构建 Anthropic 请求体。设置 max_tokens、system、temperature、top_p、top_k、thinking 模式（支持 `{ type: "enabled" }` 和 `{ type: "adaptive" }`）、tools（转换为 Anthropic 格式）、tool_choice（auto/any/none）以及 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,12 +226,15 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │           ├── 发出 thinking 指示器 "Reading image..."
   │           ├── 调用 callVisionModel() 获取描述
   │           ├── 关闭 thinking 指示器
-  │           └── 构建第二轮 API 请求 (assistant tool_call + tool_result)
+  │           ├── 用户取消则跳过第二轮
+  │           └── 创建独立 AbortController 用于第二轮请求
   │               ├── 保留 temperature/reasoning_effort 等原始参数
+  │               ├── Anthropic 模式额外恢复 system 和 thinking 配置
   │               └── DeepSeek 兼容注入 reasoning_content
   │
   ├── 12. 错误处理:
-  │        ├── 超时 (aborted) → 友好超时提示
+  │        ├── 用户取消（token.isCancellationRequested）→ 直接重新抛出
+  │        ├── 超时（abortController.signal.aborted）→ 友好超时提示
   │        ├── 连接被终止 → 友好终止提示
   │        └── 其他错误 → 原样抛出
   │
@@ -464,10 +467,15 @@ src/
 计算文本或消息的 Token 数量。委托给 `countMessageTokens()`。
 
 #### `provideLanguageModelChatResponse(model, messages, options, progress, token): Promise<void>`
-核心方法：处理聊天请求，流式返回响应。包括模型配置获取（内置模型 → Zen 模型回退）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析、图片代理拦截处理和错误处理。
+核心方法：处理聊天请求，流式返回响应。包括模型配置获取（内置模型 → Zen 模型回退）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析、图片代理拦截处理和错误处理。错误处理区分三种情况：用户取消（直接重新抛出原始错误）、超时（友好超时提示）、连接被终止（友好终止提示）。
 
 #### `private async _handleInterceptedToolCall(params): Promise<void>`
 处理图片代理拦截。检测 API 实例的 `interceptedToolCall`，读取设置 `opencodego.visionProxyModel`/`visionProxyPrompt`/`visionProxyThinking`，发出 thinking 指示器，使用模型的具体 query 调用 `callVisionModel()` 获取答案，构建第二轮 API 请求（assistant tool_call + tool result），保留 temperature/reasoning_effort 等原始参数，DeepSeek 兼容注入 `reasoning_content`。
+
+- 视觉模型调用期间用户取消则跳过第二轮。
+- 构建第二轮前清除第一轮超时定时器，避免误中断。
+- 创建独立 AbortController 用于第二轮 fetch，带独立超时。
+- Anthropic 模式额外恢复 `system` 内容（`_systemContent`）和 `thinking` 参数。
 
 #### `private async ensureApiKey(): Promise<string | undefined>`
 确保 API Key 存在于 SecretStorage 中，缺失时弹出输入框提示用户输入。
@@ -736,7 +744,7 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 ### 4.23 `src/vision/imageProxy.ts`
 
 #### `callVisionModel(imageData, mimeType, visionModelId, query, token): Promise<string>`
-调用视觉模型回答关于图片的查询。使用 `vscode.lm.selectChatModels()` 查找模型，发送图片+查询文本，收集流式回答返回。与旧版 `describe_image` 不同，`query` 参数来自模型的 `ask_image` 工具调用，允许针对性提问（如"按钮是什么颜色？"）。支持 thinking 模式配置，通过 `opencodego.visionProxyThinking` 设置控制是否启用推理。
+调用视觉模型回答关于图片的查询。使用 `vscode.lm.selectChatModels()` 查找模型，发送图片+查询文本，收集流式回答返回。与旧版 `describe_image` 不同，`query` 参数来自模型的 `ask_image` 工具调用，允许针对性提问（如"按钮是什么颜色？"）。支持 thinking 模式配置，通过 `opencodego.visionProxyThinking` 设置控制，使用标准 `modelOptions` 字段传递 `reasoning_effort`。
 
 ---
 
@@ -854,7 +862,7 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 构建 OpenAI 请求体。设置 temperature、top_p、max_tokens、reasoning_effort（adaptive 模式时跳过）、thinking 模式（支持 `{ type: "enabled" }` 和 `{ type: "adaptive" }`）、stop、tools、tool_choice 以及各种惩罚参数和 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
-处理 OpenAI SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，处理 `[DONE]` 标记，解析 usage 用量信息，委托 `processDelta()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。
+处理 OpenAI SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，处理 `[DONE]` 标记，解析 usage 用量信息，委托 `processDelta()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。在 `finally` 块中 dispose 该回调，防止多次调用 `processStreamingResponse` 时回调累积。
 
 #### `private processDelta(delta, progress): Promise<boolean>`
 处理单个 stream delta。按序处理：推理内容 → XML think 块 → 文本内容 → 工具调用。支持 `reasoning_details` 数组（OpenRouter 格式）。
@@ -918,7 +926,7 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 构建 Anthropic 请求体。设置 max_tokens、system、temperature、top_p、top_k、thinking 模式（支持 `{ type: "enabled" }` 和 `{ type: "adaptive" }`）、tools（转换为 Anthropic 格式）、tool_choice（auto/any/none）以及 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
-处理 Anthropic SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，委托 `processAnthropicChunk()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。
+处理 Anthropic SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，委托 `processAnthropicChunk()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。在 `finally` 块中 dispose 该回调，防止多次调用 `processStreamingResponse` 时回调累积。
 
 #### `private processAnthropicChunk(chunk, progress): Promise<void>`
 处理 Anthropic 流式块。支持的事件类型：

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -62,6 +62,22 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 							mimeType: part.mimeType,
 						});
 					}
+					// Also scan inside tool result content for images
+					// (e.g., when view_image tool returns an image in a previous turn)
+					if (isToolResultPart(part)) {
+						const toolContent = (part as { content?: ReadonlyArray<unknown> }).content;
+						if (toolContent) {
+							for (const inner of toolContent) {
+								if (inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
+									if (!imagesToStore) imagesToStore = [];
+									imagesToStore.push({
+										data: inner.data,
+										mimeType: inner.mimeType,
+									});
+								}
+							}
+						}
+					}
 				}
 			}
 			if (imagesToStore && imagesToStore.length > 0) {
@@ -95,7 +111,19 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 					});
 				} else if (isToolResultPart(part)) {
 					const callId = (part as { callId?: string }).callId ?? "";
-					const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
+					const toolContent = (part as { content?: ReadonlyArray<unknown> }).content;
+					const toolTexts: string[] = [];
+					if (toolContent) {
+						for (const inner of toolContent) {
+							if (inner instanceof vscode.LanguageModelTextPart) {
+								toolTexts.push(inner.value);
+							} else if (!modelSupportsVision && inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
+								toolTexts.push(`[Image data from previous tool call (imageIndex=${imageIndex})]`);
+								imageIndex++;
+							}
+						}
+					}
+					const content = toolTexts.join("\n").trim();
 					toolResults.push({
 						type: "tool_result",
 						tool_use_id: callId,

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -334,10 +334,11 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		const reader = responseBody.getReader();
 		const decoder = new TextDecoder();
 		let buffer = "";
+		let cancelDisposable: vscode.Disposable | undefined;
 
 		// Immediately cancel the stream when user cancels, so reader.read() won't stay pending
 		if (token.onCancellationRequested) {
-			token.onCancellationRequested(() => {
+			cancelDisposable = token.onCancellationRequested(() => {
 				reader.cancel().catch(() => {});
 			});
 		}
@@ -391,6 +392,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			logger.error("anthropic.stream.error", { modelId, error: e instanceof Error ? e.message : String(e) });
 			throw e;
 		} finally {
+			cancelDisposable?.dispose();
 			reader.releaseLock();
 			this.reportEndThinking(progress);
 		}

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -341,10 +341,11 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         const reader = responseBody.getReader();
         const decoder = new TextDecoder();
         let buffer = "";
+        let cancelDisposable: vscode.Disposable | undefined;
 
         // Immediately cancel the stream when user cancels, so reader.read() won't stay pending
         if (token.onCancellationRequested) {
-            token.onCancellationRequested(() => {
+            cancelDisposable = token.onCancellationRequested(() => {
                 reader.cancel().catch(() => {});
             });
         }
@@ -425,6 +426,7 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
             logger.error("openai.stream.error", { modelId, error: e instanceof Error ? e.message : String(e) });
             throw e;
         } finally {
+            cancelDisposable?.dispose();
             reader.releaseLock();
             this.reportEndThinking(progress);
         }

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -67,6 +67,22 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                             mimeType: part.mimeType,
                         });
                     }
+                    // Also scan inside tool result content for images
+                    // (e.g., when view_image tool returns an image in a previous turn)
+                    if (isToolResultPart(part)) {
+                        const toolContent = (part as { content?: ReadonlyArray<unknown> }).content;
+                        if (toolContent) {
+                            for (const inner of toolContent) {
+                                if (inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
+                                    if (!imagesToStore) imagesToStore = [];
+                                    imagesToStore.push({
+                                        data: inner.data,
+                                        mimeType: inner.mimeType,
+                                    });
+                                }
+                            }
+                        }
+                    }
                 }
             }
             if (imagesToStore && imagesToStore.length > 0) {
@@ -108,7 +124,19 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                     toolCalls.push({ id, type: "function", function: { name: part.name, arguments: args } });
                 } else if (isToolResultPart(part)) {
                     const callId = (part as { callId?: string }).callId ?? "";
-                    const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
+                    const toolContent = (part as { content?: ReadonlyArray<unknown> }).content;
+                    const toolTexts: string[] = [];
+                    if (toolContent) {
+                        for (const inner of toolContent) {
+                            if (inner instanceof vscode.LanguageModelTextPart) {
+                                toolTexts.push(inner.value);
+                            } else if (!modelSupportsVision && inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
+                                toolTexts.push(`[Image data from previous tool call (imageIndex=${imageIndex})]`);
+                                imageIndex++;
+                            }
+                        }
+                    }
+                    const content = toolTexts.join("\n").trim();
                     toolResults.push({ callId, content });
                 } else if (part instanceof vscode.LanguageModelThinkingPart) {
                     const content = Array.isArray(part.value) ? part.value.join("") : part.value;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -628,6 +628,19 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             if (params.um?.temperature !== undefined && params.um.temperature !== null) {
                 secondBody.temperature = params.um.temperature;
             }
+            // Restore system content for second round (extracted by convertMessages)
+            const anthropicSystemContent = (params.api as any)._systemContent as string | undefined;
+            if (anthropicSystemContent) {
+                secondBody.system = anthropicSystemContent;
+            }
+            // Preserve thinking mode for second round (Anthropic-compatible)
+            if (params.um?.enable_thinking === true) {
+                if (params.um?.reasoning_effort === 'adaptive') {
+                    secondBody.thinking = { type: "adaptive" };
+                } else {
+                    secondBody.thinking = { type: "enabled", budget_tokens: 8192 };
+                }
+            }
 
             const secondUrl = params.baseUrl.replace(/\/+$/, "");
             const url = secondUrl.endsWith("/v1")

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -340,6 +340,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 await anthropicApi.processStreamingResponse(response.body, trackingProgress, token);
 
                 // --- Second round: handle ask_image tool call interception ---
+                // Clear the first-round timeout before starting the second round
+                clearTimeout(timeoutId);
                 await this._handleInterceptedToolCall({
                     api: anthropicApi,
                     apiMode: "anthropic",
@@ -412,6 +414,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 await openaiApi.processStreamingResponse(response.body, trackingProgress, token);
 
                 // --- Second round: handle ask_image tool call interception ---
+                // Clear the first-round timeout before starting the second round
+                clearTimeout(timeoutId);
                 await this._handleInterceptedToolCall({
                     api: openaiApi,
                     apiMode: "openai",
@@ -448,12 +452,22 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         } catch (err) {
             // Determine if the request was aborted/terminated (friendly message instead of raw error)
             const errMessage = err instanceof Error ? err.message : String(err);
-            const isTimeout = abortController.signal.aborted;
+            // Distinguish user cancellation from timeout: the AbortController is aborted
+            // by BOTH the timeout timer AND the user cancellation listener; check the
+            // VS Code cancellation token to tell them apart.
+            const isUserCancelled = token.isCancellationRequested;
+            const isTimeout = abortController.signal.aborted && !isUserCancelled;
             const isForceTerminated =
                 !isTimeout &&
+                !isUserCancelled &&
                 (errMessage.includes("terminated") ||
                  errMessage.includes("aborted") ||
                  (err instanceof Error && err.name === "AbortError"));
+
+            // If user cancelled, just re-throw the original error without wrapping
+            if (isUserCancelled) {
+                throw err;
+            }
 
             if (isTimeout || isForceTerminated) {
                 logger.error("request.timeout", {
@@ -584,6 +598,30 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             new vscode.LanguageModelThinkingPart("", visionThinkId) as unknown as LanguageModelResponsePart
         );
 
+        // If user cancelled during the vision model call, skip second round
+        if (params.token.isCancellationRequested) {
+            logger.info("vision.skipped-second-round", { reason: "user_cancelled" });
+            return;
+        }
+
+        // Create a fresh abort controller for the second round to avoid
+        // interference from the first round's timeout timer
+        const secondAbortController = new AbortController();
+        const secondTimeoutMs = vscode.workspace.getConfiguration().get<number>("opencodego.requestTimeout", 600000);
+        const secondTimeoutId = setTimeout(() => {
+            if (!secondAbortController.signal.aborted) {
+                secondAbortController.abort();
+            }
+        }, secondTimeoutMs);
+        // Forward user cancellation to the new controller
+        if (params.token.onCancellationRequested) {
+            params.token.onCancellationRequested(() => {
+                if (!secondAbortController.signal.aborted) {
+                    secondAbortController.abort();
+                }
+            });
+        }
+
         // Build second-round messages and make another API request
         const api = params.api;
         // Get the original API messages (specific to each format)
@@ -652,7 +690,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     method: "POST",
                     headers: params.requestHeaders,
                     body: JSON.stringify(secondBody),
-                    signal: params.abortController.signal,
+                    signal: secondAbortController.signal,
                 });
                 if (!res.ok) {
                     const errorText = await res.text();
@@ -664,6 +702,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             if (secondResponse.body) {
                 await api.processStreamingResponse(secondResponse.body, params.trackingProgress, params.token);
             }
+            clearTimeout(secondTimeoutId);
         } else {
             // OpenAI format second round
             const secondMessages = [
@@ -724,7 +763,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     method: "POST",
                     headers: params.requestHeaders,
                     body: JSON.stringify(secondBody),
-                    signal: params.abortController.signal,
+                    signal: secondAbortController.signal,
                 });
                 if (!res.ok) {
                     const errorText = await res.text();
@@ -736,6 +775,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             if (secondResponse.body) {
                 await api.processStreamingResponse(secondResponse.body, params.trackingProgress, params.token);
             }
+            clearTimeout(secondTimeoutId);
         }
     }
 

--- a/src/vision/imageProxy.ts
+++ b/src/vision/imageProxy.ts
@@ -30,11 +30,11 @@ export async function callVisionModel(
         [dataPart, textPart]
     );
 
-    const options: vscode.LanguageModelChatRequestOptions & { reasoningEffort?: string } = {};
+    const options: vscode.LanguageModelChatRequestOptions = {};
     // Enable thinking for better image analysis when the model supports it
     const visionThinking = vscode.workspace.getConfiguration().get<boolean>("opencodego.visionProxyThinking", true);
     if (visionThinking) {
-        options.reasoningEffort = "high";
+        options.modelOptions = { reasoning_effort: "high" };
     }
     const response = await visionModel.sendRequest([msg], options, token);
     let description = "";


### PR DESCRIPTION
### Changes

**1. Tool result image detection for ask_image proxy**
- Detect images nested inside `LanguageModelToolResultPart.content` during message conversion for both OpenAI and Anthropic formats, ensuring images returned via tools (e.g., `view_image`) are stored and injected as `ask_image` tool definitions.
- Replace images in tool result content with text references containing the correct `imageIndex` for non-vision models.

**2. Anthropic second-round request completeness**
- Restore `system` content extracted by `convertMessages` into `_systemContent` for the second API round, fixing missing behavior context.
- Add `thinking` mode configuration to Anthropic second-round requests, matching the OpenAI second-round behavior.

**3. Second-round request timeout isolation**
- Clear the first-round timeout timer before entering the second round to prevent premature timeout.
- Create a fresh `AbortController` with its own timeout inside `_handleInterceptedToolCall`, decoupling second-round fetch cancellation from the first round.

**4. User cancellation vs timeout distinction**
- Check `token.isCancellationRequested` first in the error handler to distinguish user cancellation from actual timeouts.
- Re-throw the original error for user cancellation without wrapping it as a timeout.
- Add early return in `_handleInterceptedToolCall` when user cancels during the vision model call.

**5. Minor improvements**
- Use standard `modelOptions` dict in `callVisionModel` instead of a type intersection for `reasoningEffort`.
- Dispose the `token.onCancellationRequested` callback in `processStreamingResponse` finally block to prevent callback accumulation across multiple streaming sessions.

### Files Changed

| File | Change |
|------|--------|
| `src/openai/openaiApi.ts` | Scan `LanguageModelToolResultPart.content` for nested images; emit tool result image references. |
| `src/anthropic/anthropicApi.ts` | Same tool result image scan and reference injection for Anthropic format. |
| `src/provider.ts` | Add system/thinking to Anthropic second round; isolate second-round AbortController; fix cancel/timeout misclassification. |
| `src/vision/imageProxy.ts` | Use standard `modelOptions` for reasoning effort. |
| `AGENTS.md` | Sync documentation with all pipeline changes. |