### PR TITLE
fix: store images locally per instance and support multi-round vision proxying

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,15 +223,17 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │
   ├── 11. 图片代理拦截处理:
   │       └── _handleInterceptedToolCall()
-  │           ├── 检查 interceptedToolCall
+  │           ├── 检查 interceptedToolCall（循环，最多 visionMaxRounds 次）
   │           ├── 发出 thinking 指示器 "Reading image..."
   │           ├── 调用 callVisionModel() 获取描述
   │           ├── 关闭 thinking 指示器
-  │           ├── 用户取消则跳过第二轮
-  │           └── 创建独立 AbortController 用于第二轮请求
-  │               ├── 保留 temperature/reasoning_effort 等原始参数
-  │               ├── Anthropic 模式额外恢复 system 和 thinking 配置
-  │               └── DeepSeek 兼容注入 reasoning_content
+  │           ├── 用户取消则跳过本轮
+  │           ├── 创建独立 AbortController 用于本轮请求
+  │           │   ├── 保留 temperature/reasoning_effort 等原始参数
+  │           │   ├── Anthropic 模式额外恢复 system 和 thinking 配置
+  │           │   └── DeepSeek 兼容注入 reasoning_content
+  │           ├── 注入工具: 本轮注入 VS Code 原生工具 + ask_image（共存）
+  │           └── 循环: 若模型再次调用 ask_image 则继续下一轮，无限追问
   │
   ├── 12. 错误处理:
   │        ├── 用户取消（token.isCancellationRequested）→ 直接重新抛出
@@ -288,43 +290,43 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │
   ├── 1. convertMessages()
   │      模型 vision=false，有 image → 替换为 "[The user sent an image (imageIndex=N)... I MUST call the ask_image tool...]"
-  │      原图数据存入 CommonApi.storedImages 静态池
+  │      原图数据存入实例的 _localImages 数组
   │      同时递归扫描 tool result 内嵌的图片一并存入
-  │      记录 _hasStoredImages = true，保存 _originalApiMessages
+  │      记录 _hasImages = true，保存 _originalApiMessages
   │
   ├── 2. prepareRequestBody()
-  │      有 stored images → 注入 ask_image 工具定义到 tools 列表
+  │      有 _localImages → 注入 ask_image 工具定义到 tools 列表
   │      设置 tool_choice = "auto"（DeepSeek 等模型拒绝强制 tool_choice）
   │
-  ├── 3. 第一次 API 请求（含 ask_image 工具）
+  ├── 3. 第一次 API 请求（含 ask_image + VS Code 原生工具）
   │      └── 模型自主决定是否调用 ask_image
   │
   ├── 4. processDelta() / processAnthropicChunk() 拦截
   │      ask_image 被缓存到 interceptedToolCall（不在 progress 中发出）
   │      tryEmitBufferedToolCall() 和 flushToolCallBuffers() 同时跳过 ask_image
   │
-  ├── 5. provider._handleInterceptedToolCall() 处理
-  │      ├── 读取设置: visionProxyModel (默认 qwen3.6-plus)
-  │      │              visionProxyThinking (默认 false)
-  │      ├── 发出 LanguageModelThinkingPart("Reading image...")
-  │      ├── 使用模型的具体 query 调用 callVisionModel()
-  │      │   └── 发送图片 + 查询到视觉模型，收集流式回答
-  │      ├── 发出 LanguageModelThinkingPart(" done") + 关闭 thinking
-  │      └── 构建第二轮消息（assistant tool_call + tool result）
-  │
-  └── 6. 第二次 API 请求
-         ├── 复制 _originalApiMessages + 追加 assistant(tool_calls) + tool(result)
-         ├── 保留 temperature、reasoning_effort 等参数
-         ├── DeepSeek 兼容: assistant 消息中注入 reasoning_content
-         └── 流式输出最终回答到 progress
+  └── 5. _handleInterceptedToolCall() 循环（多轮追问）
+         for round = 1 to visionMaxRounds:
+           ├── 读取 interceptedToolCall
+           ├── 发出 LanguageModelThinkingPart("Reading image...")
+           ├── 使用模型的具体 query 调用 callVisionModel()
+           │   └── 发送图片 + 查询到视觉模型，收集流式回答
+           ├── 关闭 thinking
+           ├── 构建本轮消息: 追加 assistant(tool_call) + tool(result)
+           ├── 注入工具: VS Code 原生工具 + ask_image（两者共存）
+           ├── 发送 API 请求并流式处理
+           ├── 若模型再次调用 ask_image → 继续循环
+           └── 若模型未调 ask_image → 结束
 ```
 
-#### 第二轮请求特点
+#### 多轮请求特点
 
-- **OpenAI 模式**: 使用 `tool_calls` + `tool` role 消息格式构建第二轮
-- **Anthropic 模式**: 使用 `tool_use` + `tool_result` content block 格式构建第二轮
-- **参数保留**: 第二轮保留 temperature、top_p、thinking 模式等原始参数
-- **绕过工具注入**: 第二轮不注入工具定义（减少 token 消耗）
+- **支持无限追问**: 模型拿到图片描述后可以继续调用 ask_image 追问细节（最多 `visionMaxRounds` 次，默认 5）
+- **工具共存**: 每轮同时注入 VS Code 原生工具（read_file 等）+ ask_image，模型可混合使用
+- **图片数据生命周期**: 图片存于 API 实例的 `_localImages` 数组，请求结束后随实例 GC 自动回收
+- **OpenAI 模式**: 使用 `tool_calls` + `tool` role 消息格式构建每轮
+- **Anthropic 模式**: 使用 `tool_use` + `tool_result` content block 格式构建每轮
+- **参数保留**: 每轮保留 temperature、top_p、thinking 模式等原始参数
 - **DeepSeek 兼容**: 对 DeepSeek 模型的 assistant tool_call 消息注入 reasoning_content 字段
 
 ### 2.6 Git 提交消息生成流程
@@ -405,7 +407,7 @@ src/
 | 文件 | 行数 | 职责 |
 |------|------|------|
 | `extension.ts` | ~210 | 扩展激活/停用，注册 Provider 和 6 条命令，首次安装欢迎页引导 |
-| `provider.ts` | ~670 | 实现 `LanguageModelChatProvider`，处理聊天请求全流程及图片代理第二轮处理 |
+| `provider.ts` | ~700 | 实现 `LanguageModelChatProvider`，处理聊天请求全流程及图片代理多轮循环处理 |
 | `models.ts` | ~225 | 16 个内置模型定义，模型配置查询（所有模型声明 `imageInput: true`） |
 | `types.ts` | ~95 | `OpenCodeGoModelItem`, `ModelPreset`, `ModelsResponse`, `RetryConfig` 等类型 |
 | `commonApi.ts` | ~458 | `CommonApi<TMessage,TRequestBody>` 抽象基类（图片存储、工具调用拦截） |
@@ -470,11 +472,11 @@ src/
 核心方法：处理聊天请求，流式返回响应。包括模型配置获取（内置模型 → Zen 模型回退）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析、图片代理拦截处理和错误处理。错误处理区分三种情况：用户取消（直接重新抛出原始错误）、超时（友好超时提示）、连接被终止（友好终止提示）。
 
 #### `private async _handleInterceptedToolCall(params): Promise<void>`
-处理图片代理拦截。检测 API 实例的 `interceptedToolCall`，读取设置 `opencodego.visionProxyModel`/`visionProxyThinking`，发出 thinking 指示器，使用模型的具体 query 调用 `callVisionModel()` 获取答案，构建第二轮 API 请求（assistant tool_call + tool result），保留 temperature/reasoning_effort 等原始参数，DeepSeek 兼容注入 `reasoning_content`。
+处理图片代理拦截。循环处理最多 `opencodego.visionMaxRounds` 轮（默认 5）。每轮检测 API 实例的 `interceptedToolCall`，发出 thinking 指示器，使用模型的具体 query 调用 `callVisionModel()` 获取答案，构建本轮 API 请求（追加 assistant tool_call + tool result），注入 VS Code 原生工具 + ask_image 供模型继续使用，保留 temperature/reasoning_effort 等原始参数，DeepSeek 兼容注入 `reasoning_content`。模型不再调用 ask_image 时退出循环。
 
-- 视觉模型调用期间用户取消则跳过第二轮。
-- 构建第二轮前清除第一轮超时定时器，避免误中断。
-- 创建独立 AbortController 用于第二轮 fetch，带独立超时。
+- 视觉模型调用期间用户取消则跳过本轮。
+- 每轮创建独立 AbortController，带独立超时。
+- 每轮注入 VS Code 原生工具 + ask_image，确保模型可以混合使用。
 - Anthropic 模式额外恢复 `system` 内容（`_systemContent`）和 `thinking` 参数。
 
 #### `private async ensureApiKey(): Promise<string | undefined>`
@@ -589,10 +591,8 @@ API 实现的抽象基类。
 | `_modelId` | `string` | 模型 ID |
 | `_onUsage` | `((usage: StreamUsage) => void) \| undefined` | 用量回调 |
 | `interceptedToolCall` | `InterceptedToolCall \| null` | 被拦截的 ask_image 工具调用 |
-| `_imageStoreKey` | `string \| null` | 当前实例的图片存储键 |
-| `_originalApiMessages` | `any[] \| null` | 转换后的原始 API 消息，用于构建第二轮请求 |
-| `storedImages` | `Map<string, StoredImage[]>`（静态） | 请求图片数据暂存池 |
-| `generateImageStoreKey()` | `string`（静态） | 生成唯一的图片存储键 |
+| `_localImages` | `StoredImage[]` | 实例局部图片数据，请求结束随 GC 回收 |
+| `_originalApiMessages` | `any[] \| null` | 转换后的原始 API 消息，用于构建多轮请求 |
 
 #### `abstract convertMessages(messages, modelConfig): TMessage[]`
 将 VS Code 聊天消息转换为特定 API 格式的消息数组。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。
@@ -610,10 +610,7 @@ API 实现的抽象基类。
 清空所有工具调用缓冲区，发射剩余的工具调用。拦截 `ask_image` 存入 `interceptedToolCall`。
 
 #### `public getStoredImage(imageIndex): StoredImage | undefined`
-从静态 `storedImages` 池中按索引获取存储的图片数据。
-
-#### `public cleanupStoredImages(): void`
-清理此实例的存储图片。
+从实例的 `_localImages` 数组中按索引获取存储的图片数据。
 
 #### `protected adjustReadFileParameters(toolName, parameters): Record<string, unknown>`
 调整 `read_file` 工具的参数，根据配置自动扩增读取行数。

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -30,8 +30,8 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		super(modelId);
 	}
 
-	/** Whether images were stored during convertMessages for ask_image tool. */
-	private _hasStoredImages = false;
+	/** Whether images were found during convertMessages for ask_image tool. */
+	private _hasImages = false;
 
 	/** Accumulated input tokens from Anthropic message_start for usage reporting. */
 	private _anthropicInputTokens = 0;
@@ -50,13 +50,12 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		const out: AnthropicMessage[] = [];
 		let imageIndex = 0;
 
-		// Collect images to store if model doesn't support vision
-		let imagesToStore: StoredImage[] | undefined;
+		// Collect images to instance-local array if model doesn't support vision
+		const imagesToStore: StoredImage[] = [];
 		if (!modelSupportsVision) {
 			for (const m of messages) {
 				for (const part of m.content ?? []) {
 					if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
-						if (!imagesToStore) imagesToStore = [];
 						imagesToStore.push({
 							data: part.data,
 							mimeType: part.mimeType,
@@ -69,14 +68,12 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 						if (toolContent) {
 							for (const inner of toolContent) {
 								if (inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
-									if (!imagesToStore) imagesToStore = [];
 									imagesToStore.push({
 										data: inner.data,
 										mimeType: inner.mimeType,
 									});
 								} else if (inner instanceof vscode.LanguageModelTextPart) {
 									// Scan text for base64 data URI images
-									if (!imagesToStore) imagesToStore = [];
 									storeDataUriImages(inner.value, imagesToStore);
 								}
 							}
@@ -84,16 +81,13 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 					}
 					// Scan direct text parts for base64 data URI images
 					if (part instanceof vscode.LanguageModelTextPart) {
-						if (!imagesToStore) imagesToStore = [];
 						storeDataUriImages(part.value, imagesToStore);
 					}
 				}
 			}
-			if (imagesToStore && imagesToStore.length > 0) {
-				const key = CommonApi.generateImageStoreKey();
-				CommonApi.storedImages.set(key, imagesToStore);
-				this._imageStoreKey = key;
-				this._hasStoredImages = true;
+			if (imagesToStore.length > 0) {
+				this._localImages = imagesToStore;
+				this._hasImages = true;
 			}
 		}
 
@@ -297,7 +291,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			}
 		}
 		// Inject ask_image tool for non-vision models with stored images
-		if (this._hasStoredImages) {
+		if (this._hasImages) {
 			const def = ASK_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
 			anthropicToolList.push({
 				name: def.function.name,
@@ -310,7 +304,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		}
 
 		// Add tool_choice (Anthropic format)
-		if (this._hasStoredImages) {
+		if (this._hasImages) {
 			// Set to "auto" so the model can freely choose to call ask_image.
 			// The converted messages already contain strong directives telling the
 			// model it MUST use ask_image, and the tool definition is available.

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -78,10 +78,10 @@ export abstract class CommonApi<TMessage, TRequestBody> {
     public interceptedToolCall: InterceptedToolCall | null = null;
 
     /**
-     * Key used to retrieve stored images from CommonApi.storedImages.
-     * Set during convertMessages when images are stored for non-vision models.
+     * Locally stored images collected during convertMessages.
+     * Lives on the instance only — no global Map, automatically GC'd.
      */
-    protected _imageStoreKey: string | null = null;
+    protected _localImages: StoredImage[] = [];
 
     /**
      * Store the converted API messages so the provider can reference them
@@ -93,37 +93,8 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      * Get the stored images associated with this instance, if any.
      */
     public getStoredImage(imageIndex: number): StoredImage | undefined {
-        if (!this._imageStoreKey) return undefined;
-        const images = CommonApi.storedImages.get(this._imageStoreKey);
-        if (!images || imageIndex < 0 || imageIndex >= images.length) return undefined;
-        return images[imageIndex];
-    }
-
-    /**
-     * Clean up stored images for this instance.
-     */
-    public cleanupStoredImages(): void {
-        if (this._imageStoreKey) {
-            CommonApi.storedImages.delete(this._imageStoreKey);
-            this._imageStoreKey = null;
-        }
-    }
-
-    /**
-     * Static storage for images attached to the conversation.
-     * Keyed by a unique request identifier set during convertMessages.
-     */
-    public static readonly storedImages = new Map<string, StoredImage[]>();
-
-    /** Static counter for generating unique image storage keys. */
-    private static _nextImageStoreId = 0;
-
-    /**
-     * Generate a unique key for storing images in the static map.
-     */
-    public static generateImageStoreKey(): string {
-        const id = ++CommonApi._nextImageStoreId;
-        return `req_${id}`;
+        if (imageIndex < 0 || imageIndex >= this._localImages.length) return undefined;
+        return this._localImages[imageIndex];
     }
 
     constructor(modelId: string) {

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -40,14 +40,14 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
     }
 
     /**
-     * Whether images were stored during convertMessages for ask_image tool.
+     * Whether images were found during convertMessages for ask_image tool.
      */
-    private _hasStoredImages = false;
+    private _hasImages = false;
 
     /**
      * Convert VS Code chat request messages into OpenAI-compatible message objects.
      * For non-vision models, images are replaced with text references and stored
-     * in the static CommonApi.storedImages map for the ask_image tool.
+     * in instance-local _localImages for the ask_image tool.
      */
     convertMessages(
         messages: readonly LanguageModelChatRequestMessage[],
@@ -57,13 +57,12 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         const out: OpenAIChatMessage[] = [];
         let imageIndex = 0;
 
-        // Collect images to store if model doesn't support vision
-        let imagesToStore: StoredImage[] | undefined;
+        // Collect images to instance-local array if model doesn't support vision
+        const imagesToStore: StoredImage[] = [];
         if (!modelSupportsVision) {
             for (const m of messages) {
                 for (const part of m.content ?? []) {
                     if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
-                        if (!imagesToStore) imagesToStore = [];
                         imagesToStore.push({
                             data: part.data,
                             mimeType: part.mimeType,
@@ -76,14 +75,12 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                         if (toolContent) {
                             for (const inner of toolContent) {
                                 if (inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
-                                    if (!imagesToStore) imagesToStore = [];
                                     imagesToStore.push({
                                         data: inner.data,
                                         mimeType: inner.mimeType,
                                     });
                                 } else if (inner instanceof vscode.LanguageModelTextPart) {
                                     // Scan text for base64 data URI images
-                                    if (!imagesToStore) imagesToStore = [];
                                     storeDataUriImages(inner.value, imagesToStore);
                                 }
                             }
@@ -91,16 +88,13 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                     }
                     // Scan direct text parts for base64 data URI images
                     if (part instanceof vscode.LanguageModelTextPart) {
-                        if (!imagesToStore) imagesToStore = [];
                         storeDataUriImages(part.value, imagesToStore);
                     }
                 }
             }
-            if (imagesToStore && imagesToStore.length > 0) {
-                const key = CommonApi.generateImageStoreKey();
-                CommonApi.storedImages.set(key, imagesToStore);
-                this._imageStoreKey = key;
-                this._hasStoredImages = true;
+            if (imagesToStore.length > 0) {
+                this._localImages = imagesToStore;
+                this._hasImages = true;
             }
         }
 
@@ -316,13 +310,13 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
             toolsList.push(...toolConfig.tools);
         }
         // Inject ask_image tool for non-vision models with stored images
-        if (this._hasStoredImages) {
+        if (this._hasImages) {
             toolsList.push(ASK_IMAGE_TOOL_DEF);
         }
         if (toolsList.length > 0) {
             rb.tools = toolsList;
         }
-        if (this._hasStoredImages) {
+        if (this._hasImages) {
             // Set to "auto" so the model can freely choose to call ask_image.
             // Some providers (DeepSeek) reject forced function tool_choice.
             // The converted messages already contain strong directives telling the

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -551,10 +551,10 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
     }): Promise<void> {
         const api = params.api;
         const storedMessages = (api as any)._originalApiMessages as any[] | undefined;
-        const imgKey = (api as any)._imageStoreKey as string | null;
+        const hasLocalImages = ((api as any)._localImages as any[])?.length > 0;
 
         // Nothing to proxy — no stored images
-        if (!imgKey || !CommonApi.storedImages.has(imgKey)) {
+        if (!hasLocalImages) {
             logger.debug("vision.no-stored-images", { hasStoredMessages: !!storedMessages });
             return;
         }
@@ -701,7 +701,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                             });
                         }
                     }
-                    if (imgKey && CommonApi.storedImages.has(imgKey)) {
+                    if (hasLocalImages) {
                         const def = ASK_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
                         anthropicToolList.push({
                             name: def.function.name,
@@ -787,7 +787,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     if (toolConfig.tools) {
                         openaiToolList.push(...toolConfig.tools);
                     }
-                    if (imgKey && CommonApi.storedImages.has(imgKey)) {
+                    if (hasLocalImages) {
                         openaiToolList.push(ASK_IMAGE_TOOL_DEF);
                     }
                     if (openaiToolList.length > 0) {


### PR DESCRIPTION
### Changes

**1. Instance-local image storage**
- Removed global static `storedImages` Map from `CommonApi`, replaced with instance-local `_localImages` array.
- Images are now auto-GC'd when the API request instance goes out of scope, eliminating memory leaks from persistent image accumulation.
- Removed `_imageStoreKey`, `cleanupStoredImages()`, and `generateImageStoreKey()`.

**2. Multi-round vision proxy with tool coexistence**
- Changed `_handleInterceptedToolCall()` from single-round to a loop (up to `visionMaxRounds`, default 5), allowing the model to ask follow-up questions about images.
- Each round now injects **both** VS Code native tools (read_file, etc.) **and** `ask_image`, so the model can mix image queries with file operations.
- This fixes the bug where missing tool definitions in round 2 caused models (especially DeepSeek) to output tool call JSON as plain text.

**3. Content moderation error handling**
- Added `IMAGE_SENSITIVE` detection in fetch error handlers for both Anthropic and OpenAI code paths, skipping useless retries on 500 errors.
- Added user-friendly localized error message for flagged images.

### Files Changed

| File | Change |
|------|--------|
| `src/commonApi.ts` | Replace static storedImages with instance-local _localImages |
| `src/anthropic/anthropicApi.ts` | Switch to _localImages, rename _hasStoredImages to _hasImages |
| `src/openai/openaiApi.ts` | Switch to _localImages, rename _hasStoredImages to _hasImages |
| `src/provider.ts` | Multi-round loop, tool injection per round, sensitive image detection, remove cleanup calls |
| `AGENTS.md` | Sync documentation with code changes |