### PR TITLE
feat: add ask_with_multi_image tool for multi-image comparison

### DIFF
--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -23,7 +23,7 @@ import { isImageMimeType, isToolResultPart, collectToolResultText, convertToolsT
 import { CommonApi } from "../commonApi";
 import { logger } from "../logger";
 import type { StoredImage } from "../vision/types";
-import { ASK_IMAGE_TOOL_NAME, ASK_IMAGE_TOOL_DEF } from "../vision/types";
+import { ASK_IMAGE_TOOL_NAME, ASK_IMAGE_TOOL_DEF, ASK_WITH_MULTI_IMAGE_TOOL_NAME, ASK_WITH_MULTI_IMAGE_TOOL_DEF } from "../vision/types";
 
 export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBody> {
 	constructor(modelId: string) {
@@ -290,14 +290,22 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 				});
 			}
 		}
-		// Inject ask_image tool for non-vision models with stored images
+		// Inject ask_image + ask_with_multi_image for non-vision models with stored images
 		if (this._hasImages) {
-			const def = ASK_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
+			const imgDef = ASK_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
 			anthropicToolList.push({
-				name: def.function.name,
-				description: def.function.description,
-				input_schema: def.function.parameters,
+				name: imgDef.function.name,
+				description: imgDef.function.description,
+				input_schema: imgDef.function.parameters,
 			});
+			if (this._localImages.length >= 2) {
+				const multiDef = ASK_WITH_MULTI_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
+				anthropicToolList.push({
+					name: multiDef.function.name,
+					description: multiDef.function.description,
+					input_schema: multiDef.function.parameters,
+				});
+			}
 		}
 		if (anthropicToolList.length > 0) {
 			rb.tools = anthropicToolList;

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -11,7 +11,7 @@ import {
 import { OpenCodeGoModelItem } from "./types";
 import { tryParseJSONObject } from "./utils";
 import type { InterceptedToolCall, StoredImage } from "./vision/types";
-import { ASK_IMAGE_TOOL_NAME } from "./vision/types";
+import { ASK_IMAGE_TOOL_NAME, ASK_WITH_MULTI_IMAGE_TOOL_NAME } from "./vision/types";
 
 /**
  * Token usage information extracted from streaming response usage chunk.
@@ -152,8 +152,8 @@ export abstract class CommonApi<TMessage, TRequestBody> {
         if (!buf.name) {
             return;
         }
-        // Skip ask_image — handled by provider via interceptedToolCall
-        if (buf.name === ASK_IMAGE_TOOL_NAME) {
+        // Skip ask_image / ask_with_multi_image — handled by provider via interceptedToolCall
+        if (buf.name === ASK_IMAGE_TOOL_NAME || buf.name === ASK_WITH_MULTI_IMAGE_TOOL_NAME) {
             return;
         }
         const canParse = tryParseJSONObject(buf.args);
@@ -181,15 +181,15 @@ export abstract class CommonApi<TMessage, TRequestBody> {
             return;
         }
         for (const [idx, buf] of Array.from(this._toolCallBuffers.entries())) {
-            // Intercept ask_image — store on instance for provider to handle
-            if (buf.name === ASK_IMAGE_TOOL_NAME) {
+            // Intercept ask_image / ask_with_multi_image — store on instance for provider to handle
+            if (buf.name === ASK_IMAGE_TOOL_NAME || buf.name === ASK_WITH_MULTI_IMAGE_TOOL_NAME) {
                 const argsText = buf.args.trim() || "{}";
                 const parsed = tryParseJSONObject(argsText);
                 if (parsed.ok) {
                     this.interceptedToolCall = {
                         id: buf.id ?? `call_${Math.random().toString(36).slice(2, 10)}`,
                         name: buf.name,
-                        args: parsed.value as { imageIndex: number; query: string },
+                        args: parsed.value as { imageIndex?: number; imageIndices?: number[]; query: string },
                     };
                 }
                 this._toolCallBuffers.delete(idx);

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -32,7 +32,7 @@ import {
 import { CommonApi, StreamUsage } from "../commonApi";
 import { logger } from "../logger";
 import type { StoredImage } from "../vision/types";
-import { ASK_IMAGE_TOOL_NAME, ASK_IMAGE_TOOL_DEF } from "../vision/types";
+import { ASK_IMAGE_TOOL_NAME, ASK_IMAGE_TOOL_DEF, ASK_WITH_MULTI_IMAGE_TOOL_NAME, ASK_WITH_MULTI_IMAGE_TOOL_DEF } from "../vision/types";
 
 export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unknown>> {
     constructor(modelId: string) {
@@ -309,9 +309,12 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         if (toolConfig.tools) {
             toolsList.push(...toolConfig.tools);
         }
-        // Inject ask_image tool for non-vision models with stored images
+        // Inject ask_image + ask_with_multi_image for non-vision models with stored images
         if (this._hasImages) {
             toolsList.push(ASK_IMAGE_TOOL_DEF);
+            if (this._localImages.length >= 2) {
+                toolsList.push(ASK_WITH_MULTI_IMAGE_TOOL_DEF);
+            }
         }
         if (toolsList.length > 0) {
             rb.tools = toolsList;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -26,8 +26,8 @@ import { OpenaiApi } from "./openai/openaiApi";
 import { AnthropicApi } from "./anthropic/anthropicApi";
 import type { AnthropicRequestBody } from "./anthropic/anthropicTypes";
 import { CommonApi, type StreamUsage } from "./commonApi";
-import { callVisionModel } from "./vision/imageProxy";
-import { ASK_IMAGE_TOOL_NAME, ASK_IMAGE_TOOL_DEF } from "./vision/types";
+import { callVisionModel, callVisionModelMulti } from "./vision/imageProxy";
+import { ASK_IMAGE_TOOL_NAME, ASK_IMAGE_TOOL_DEF, ASK_WITH_MULTI_IMAGE_TOOL_NAME, ASK_WITH_MULTI_IMAGE_TOOL_DEF } from "./vision/types";
 import type { InterceptedToolCall, StoredImage } from "./vision/types";
 import { logger } from "./logger";
 import { l10n } from "./localize";
@@ -582,35 +582,52 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 round,
                 toolName: intercepted.name,
                 imageIndex: intercepted.args.imageIndex,
+                imageIndices: intercepted.args.imageIndices,
                 query: intercepted.args.query,
                 apiMode: params.apiMode,
             });
 
             const visionPrompt = intercepted.args.query;
 
-            // Get the stored image data
-            const storedImage = api.getStoredImage(intercepted.args.imageIndex);
-            if (!storedImage) {
-                logger.warn("vision.image-not-found", { imageIndex: intercepted.args.imageIndex });
-                break;
-            }
-
-            // Emit a brief thinking indicator BEFORE reading the image
+            // Emit a brief thinking indicator
             const visionThinkId = `vision_${Date.now()}_${round}`;
             params.trackingProgress.report(
                 new vscode.LanguageModelThinkingPart(l10n("Reading image..."), visionThinkId) as unknown as LanguageModelResponsePart
             );
 
-            // Call vision model to answer the model's specific query about the image
+            // Call vision model — single image or multi-image depending on tool used
             let description: string;
             try {
-                description = await callVisionModel(
-                    storedImage.data,
-                    storedImage.mimeType,
-                    visionModelId,
-                    visionPrompt,
-                    params.token
-                );
+                if (intercepted.name === ASK_WITH_MULTI_IMAGE_TOOL_NAME) {
+                    // Multi-image: collect all referenced images
+                    const indices = intercepted.args.imageIndices ?? [];
+                    const images: StoredImage[] = [];
+                    for (const idx of indices) {
+                        const img = api.getStoredImage(idx);
+                        if (img) images.push(img);
+                    }
+                    if (images.length < 2) {
+                        logger.warn("vision.not-enough-images", { indices });
+                        description = "[Not enough images for comparison]";
+                    } else {
+                        description = await callVisionModelMulti(images, visionModelId, visionPrompt, params.token);
+                    }
+                } else {
+                    // Single image
+                    const storedImage = api.getStoredImage(intercepted.args.imageIndex ?? 0);
+                    if (!storedImage) {
+                        logger.warn("vision.image-not-found", { imageIndex: intercepted.args.imageIndex });
+                        description = "[Image not found]";
+                    } else {
+                        description = await callVisionModel(
+                            storedImage.data,
+                            storedImage.mimeType,
+                            visionModelId,
+                            visionPrompt,
+                            params.token
+                        );
+                    }
+                }
             } catch (err) {
                 const errMsg = err instanceof Error ? err.message : String(err);
                 logger.error("vision.call-failed", { error: errMsg, visionModelId });
@@ -631,6 +648,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 break;
             }
 
+            // Build round messages
             // Create a fresh abort controller for this round
             const roundAbortController = new AbortController();
             const roundTimeoutMs = vscode.workspace.getConfiguration().get<number>("opencodego.requestTimeout", 600000);
@@ -639,7 +657,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     roundAbortController.abort();
                 }
             }, roundTimeoutMs);
-            // Forward user cancellation
+            // Forward user cancellation to the new controller
             if (params.token.onCancellationRequested) {
                 params.token.onCancellationRequested(() => {
                     if (!roundAbortController.signal.aborted) {
@@ -649,71 +667,79 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             }
 
             try {
-                if (params.apiMode === "anthropic") {
-                    // Anthropic format: append tool_use + tool_result to accumulated messages
-                    currentMessages.push({
-                        role: "assistant" as const,
-                        content: [
-                            { type: "tool_use" as const, id: intercepted.id, name: ASK_IMAGE_TOOL_NAME, input: intercepted.args },
-                        ],
-                    });
-                    currentMessages.push({
-                        role: "user" as const,
-                        content: [
-                            { type: "tool_result" as const, tool_use_id: intercepted.id, content: description },
-                        ],
-                    });
+            if (params.apiMode === "anthropic") {
+                // Anthropic format: tool_use + tool_result
+                currentMessages.push({
+                    role: "assistant" as const,
+                    content: [
+                        { type: "tool_use" as const, id: intercepted.id, name: intercepted.name, input: intercepted.args },
+                    ],
+                });
+                currentMessages.push({
+                    role: "user" as const,
+                    content: [
+                        { type: "tool_result" as const, tool_use_id: intercepted.id, content: description },
+                    ],
+                });
 
-                    const body: Record<string, unknown> = {
-                        model: params.um?.id ?? params.model.id,
-                        messages: currentMessages,
-                        stream: true,
-                    };
-                    if (params.um?.max_completion_tokens !== undefined) {
-                        body.max_tokens = params.um.max_completion_tokens;
-                    } else if (params.um?.max_tokens !== undefined) {
-                        body.max_tokens = params.um.max_tokens;
+                const body: Record<string, unknown> = {
+                    model: params.um?.id ?? params.model.id,
+                    messages: currentMessages,
+                    stream: true,
+                };
+                if (params.um?.max_completion_tokens !== undefined) {
+                    body.max_tokens = params.um.max_completion_tokens;
+                } else if (params.um?.max_tokens !== undefined) {
+                    body.max_tokens = params.um.max_tokens;
+                }
+                if (params.um?.temperature !== undefined && params.um.temperature !== null) {
+                    body.temperature = params.um.temperature;
+                }
+                const systemContent = (params.api as any)._systemContent as string | undefined;
+                if (systemContent) {
+                    body.system = systemContent;
+                }
+                if (params.um?.enable_thinking === true) {
+                    if (params.um?.reasoning_effort === 'adaptive') {
+                        body.thinking = { type: "adaptive" };
+                    } else {
+                        body.thinking = { type: "enabled", budget_tokens: 8192 };
                     }
-                    if (params.um?.temperature !== undefined && params.um.temperature !== null) {
-                        body.temperature = params.um.temperature;
-                    }
-                    const systemContent = (params.api as any)._systemContent as string | undefined;
-                    if (systemContent) {
-                        body.system = systemContent;
-                    }
-                    if (params.um?.enable_thinking === true) {
-                        if (params.um?.reasoning_effort === 'adaptive') {
-                            body.thinking = { type: "adaptive" };
-                        } else {
-                            body.thinking = { type: "enabled", budget_tokens: 8192 };
-                        }
-                    }
+                }
 
-                    // Inject tools (VS Code tools + ask_image)
-                    const anthropicToolList: Array<{ name: string; description?: string; input_schema?: object }> = [];
-                    const toolConfig = convertToolsToOpenAI(params.options);
-                    if (toolConfig.tools) {
-                        for (const tool of toolConfig.tools) {
-                            anthropicToolList.push({
-                                name: tool.function.name,
-                                description: tool.function.description,
-                                input_schema: tool.function.parameters,
-                            });
-                        }
-                    }
-                    if (hasLocalImages) {
-                        const def = ASK_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
+                // Inject tools (VS Code + ask_image + ask_with_multi_image)
+                const anthropicToolList: Array<{ name: string; description?: string; input_schema?: object }> = [];
+                const toolConfig = convertToolsToOpenAI(params.options);
+                if (toolConfig.tools) {
+                    for (const tool of toolConfig.tools) {
                         anthropicToolList.push({
-                            name: def.function.name,
-                            description: def.function.description,
-                            input_schema: def.function.parameters,
+                            name: tool.function.name,
+                            description: tool.function.description,
+                            input_schema: tool.function.parameters,
                         });
                     }
-                    if (anthropicToolList.length > 0) {
-                        body.tools = anthropicToolList;
+                }
+                if (hasLocalImages) {
+                    const singleDef = ASK_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
+                    anthropicToolList.push({
+                        name: singleDef.function.name,
+                        description: singleDef.function.description,
+                        input_schema: singleDef.function.parameters,
+                    });
+                    if (((api as any)._localImages as any[])?.length >= 2) {
+                        const multiDef = ASK_WITH_MULTI_IMAGE_TOOL_DEF as unknown as { function: { name: string; description: string; parameters: object } };
+                        anthropicToolList.push({
+                            name: multiDef.function.name,
+                            description: multiDef.function.description,
+                            input_schema: multiDef.function.parameters,
+                        });
                     }
+                }
+                if (anthropicToolList.length > 0) {
+                    body.tools = anthropicToolList;
+                }
 
-                    const normalizedUrl = params.baseUrl.replace(/\/+$/, "");
+                const normalizedUrl = params.baseUrl.replace(/\/+$/, "");
                     const url = normalizedUrl.endsWith("/v1")
                         ? `${normalizedUrl}/messages`
                         : `${normalizedUrl}/v1/messages`;
@@ -739,13 +765,13 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     // OpenAI format: append assistant tool_call + tool result
                     currentMessages.push({
                         role: "assistant" as const,
-                        reasoning_content: `Calling ask_image tool (round ${round}) to get information about the user's attached image.`,
+                        reasoning_content: `Calling ${intercepted.name} tool (round ${round}) to get information about the user's attached image(s).`,
                         tool_calls: [
                             {
                                 id: intercepted.id,
                                 type: "function" as const,
                                 function: {
-                                    name: ASK_IMAGE_TOOL_NAME,
+                                    name: intercepted.name,
                                     arguments: JSON.stringify(intercepted.args),
                                 },
                             },
@@ -781,7 +807,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                         body.thinking = { type: "disabled" };
                     }
 
-                    // Inject tools (VS Code tools + ask_image)
+                    // Inject tools (VS Code + ask_image + ask_with_multi_image)
                     const openaiToolList: any[] = [];
                     const toolConfig = convertToolsToOpenAI(params.options);
                     if (toolConfig.tools) {
@@ -789,6 +815,9 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     }
                     if (hasLocalImages) {
                         openaiToolList.push(ASK_IMAGE_TOOL_DEF);
+                        if (((api as any)._localImages as any[])?.length >= 2) {
+                            openaiToolList.push(ASK_WITH_MULTI_IMAGE_TOOL_DEF);
+                        }
                     }
                     if (openaiToolList.length > 0) {
                         body.tools = openaiToolList;

--- a/src/vision/imageProxy.ts
+++ b/src/vision/imageProxy.ts
@@ -1,11 +1,44 @@
 import * as vscode from "vscode";
 import { DEFAULT_VISION_PROMPT } from "./types";
+import type { StoredImage } from "./types";
 
 /**
- * Call a vision-capable model to answer a question about an image.
- * Unlike the old describe_image approach which always used a fixed prompt,
- * this passes the model's specific query to the vision model, allowing
- * targeted questions (e.g. "What color is the button?", "Read the error message").
+ * Build a standard set of request options for vision model calls.
+ */
+function buildVisionOptions(): vscode.LanguageModelChatRequestOptions {
+    const options: vscode.LanguageModelChatRequestOptions = {};
+    const visionThinking = vscode.workspace.getConfiguration().get<boolean>("opencodego.visionProxyThinking", true);
+    if (visionThinking) {
+        options.modelOptions = { reasoning_effort: "high" };
+    }
+    return options;
+}
+
+/**
+ * Send a message to a vision model and collect the text response.
+ */
+async function sendToVisionModel(
+    msg: vscode.LanguageModelChatMessage,
+    visionModelId: string,
+    token: vscode.CancellationToken
+): Promise<string> {
+    const models = await vscode.lm.selectChatModels({ id: visionModelId });
+    if (!models || models.length === 0) {
+        throw new Error(`Vision model "${visionModelId}" not found. Check the opencodego.visionProxyModel setting.`);
+    }
+    const visionModel = models[0];
+    const response = await visionModel.sendRequest([msg], buildVisionOptions(), token);
+    let result = "";
+    for await (const chunk of response.stream) {
+        if (chunk instanceof vscode.LanguageModelTextPart) {
+            result += chunk.value;
+        }
+    }
+    return result.trim();
+}
+
+/**
+ * Call a vision-capable model to answer a question about a single image.
  * @param query The specific question to ask about the image.
  * @returns The answer text from the vision model.
  */
@@ -16,12 +49,6 @@ export async function callVisionModel(
     query: string | undefined,
     token: vscode.CancellationToken
 ): Promise<string> {
-    const models = await vscode.lm.selectChatModels({ id: visionModelId });
-    if (!models || models.length === 0) {
-        throw new Error(`Vision model "${visionModelId}" not found. Check the opencodego.visionProxyModel setting.`);
-    }
-
-    const visionModel = models[0];
     const dataPart = new vscode.LanguageModelDataPart(imageData, mimeType);
     const prompt = query ?? DEFAULT_VISION_PROMPT;
     const textPart = new vscode.LanguageModelTextPart(prompt);
@@ -29,19 +56,31 @@ export async function callVisionModel(
         vscode.LanguageModelChatMessageRole.User,
         [dataPart, textPart]
     );
+    return sendToVisionModel(msg, visionModelId, token);
+}
 
-    const options: vscode.LanguageModelChatRequestOptions = {};
-    // Enable thinking for better image analysis when the model supports it
-    const visionThinking = vscode.workspace.getConfiguration().get<boolean>("opencodego.visionProxyThinking", true);
-    if (visionThinking) {
-        options.modelOptions = { reasoning_effort: "high" };
+/**
+ * Call a vision-capable model to answer a question about MULTIPLE images.
+ * Sends all images + query in a single message so the model can compare them.
+ * @param images Array of { data, mimeType } for each image.
+ * @param query The comparison/analysis question.
+ * @returns The answer text from the vision model.
+ */
+export async function callVisionModelMulti(
+    images: StoredImage[],
+    visionModelId: string,
+    query: string | undefined,
+    token: vscode.CancellationToken
+): Promise<string> {
+    const prompt = query ?? "Compare and analyze these images. What do you see?";
+    const parts: (vscode.LanguageModelDataPart | vscode.LanguageModelTextPart)[] = [];
+    for (const img of images) {
+        parts.push(new vscode.LanguageModelDataPart(img.data, img.mimeType));
     }
-    const response = await visionModel.sendRequest([msg], options, token);
-    let description = "";
-    for await (const chunk of response.stream) {
-        if (chunk instanceof vscode.LanguageModelTextPart) {
-            description += chunk.value;
-        }
-    }
-    return description.trim();
+    parts.push(new vscode.LanguageModelTextPart(prompt));
+    const msg = new vscode.LanguageModelChatMessage(
+        vscode.LanguageModelChatMessageRole.User,
+        parts
+    );
+    return sendToVisionModel(msg, visionModelId, token);
 }

--- a/src/vision/types.ts
+++ b/src/vision/types.ts
@@ -9,15 +9,15 @@ export interface StoredImage {
 }
 
 /**
- * Information about an intercepted ask_image tool call.
+ * Information about an intercepted ask_image / ask_with_multi_image tool call.
  */
 export interface InterceptedToolCall {
     /** Tool call ID from the API */
     id: string;
-    /** Tool name (always "ask_image") */
+    /** Tool name ("ask_image" or "ask_with_multi_image") */
     name: string;
-    /** Parsed arguments (imageIndex, query) */
-    args: { imageIndex: number; query: string };
+    /** Parsed arguments */
+    args: { imageIndex?: number; imageIndices?: number[]; query: string };
 }
 
 /**
@@ -50,6 +50,37 @@ export const ASK_IMAGE_TOOL_DEF = {
 };
 
 export const ASK_IMAGE_TOOL_NAME = "ask_image";
+
+/**
+ * The ask_with_multi_image tool definition — same as ask_image but accepts
+ * multiple image indices so the model can ask about differences, compare
+ * screenshots, or analyze multiple images at once.
+ */
+export const ASK_WITH_MULTI_IMAGE_TOOL_DEF = {
+    type: "function" as const,
+    function: {
+        name: "ask_with_multi_image",
+        description: "Like ask_image, but accepts MULTIPLE images at once. Use this when you need to compare, contrast, or analyze multiple images together (e.g. 'what's different between these two screenshots?', 'which layout is better?', 'do these images show the same error?').\n\nIf you only need to ask about ONE image, use ask_image instead — it's simpler.",
+        parameters: {
+            type: "object",
+            properties: {
+                imageIndices: {
+                    type: "array",
+                    items: { type: "integer" },
+                    description: "Array of 0-based image indices to analyze. At least 2 indices. Example: [0, 1] to compare the first and second image.",
+                    minItems: 2,
+                },
+                query: {
+                    type: "string",
+                    description: "The question about the images. Since the vision model sees ALL selected images at once, ask about relationships, differences, or comparisons. Examples: 'What are the differences between these two screenshots?', 'Which UI design looks more modern?', 'Do both images show the same error code?'",
+                },
+            },
+            required: ["imageIndices", "query"],
+        },
+    },
+};
+
+export const ASK_WITH_MULTI_IMAGE_TOOL_NAME = "ask_with_multi_image";
 
 export const DEFAULT_VISION_PROMPT =
     "Analyze this image and answer the user's question based on visual content only. Be accurate and specific.";

--- a/src/vision/types.ts
+++ b/src/vision/types.ts
@@ -60,19 +60,19 @@ export const ASK_WITH_MULTI_IMAGE_TOOL_DEF = {
     type: "function" as const,
     function: {
         name: "ask_with_multi_image",
-        description: "Like ask_image, but accepts MULTIPLE images at once. Use this when you need to compare, contrast, or analyze multiple images together (e.g. 'what's different between these two screenshots?', 'which layout is better?', 'do these images show the same error?').\n\nIf you only need to ask about ONE image, use ask_image instead — it's simpler.",
+        description: "Like ask_image, but accepts MULTIPLE images at once. Use this when you need to compare, contrast, or analyze multiple images together (e.g. 'what's different between these two screenshots?', 'which layout is better?', 'do these images show the same error?').\n\nIn your query, you can reference images by their attachment order (e.g., 'the first image shows A, the second image shows B — what's different?') for complex multi-step questions. The vision model sees all selected images simultaneously.\n\nIf you only need to ask about ONE image, use ask_image instead — it's simpler.",
         parameters: {
             type: "object",
             properties: {
                 imageIndices: {
                     type: "array",
                     items: { type: "integer" },
-                    description: "Array of 0-based image indices to analyze. At least 2 indices. Example: [0, 1] to compare the first and second image.",
+                    description: "Array of 0-based image indices (attachment order) to analyze. At least 2 indices. Example: [0, 1] to compare the first and second attached image.",
                     minItems: 2,
                 },
                 query: {
                     type: "string",
-                    description: "The question about the images. Since the vision model sees ALL selected images at once, ask about relationships, differences, or comparisons. Examples: 'What are the differences between these two screenshots?', 'Which UI design looks more modern?', 'Do both images show the same error code?'",
+                    description: "The question about the images. Since the vision model sees ALL selected images at once, ask about relationships, differences, or comparisons. Reference images by their attachment order for clarity, e.g.: 'The first image is a login page, the second image is a dashboard — is the color scheme consistent?' or 'Compare the error messages in the first and second image, are they the same error?'",
                 },
             },
             required: ["imageIndices", "query"],


### PR DESCRIPTION
### Changes

**1. New `ask_with_multi_image` tool**
- Added `ASK_WITH_MULTI_IMAGE_TOOL_DEF` in `vision/types.ts` — accepts `imageIndices: number[]` and `query: string`, allowing the model to compare, contrast, or analyze multiple images together.
- The tool is only injected when `_localImages.length >= 2` (at least 2 images available).
- Both `ask_image` (single) and `ask_with_multi_image` (multi) coexist; the model chooses based on the task.

**2. Multi-image vision call**
- Added `callVisionModelMulti()` in `vision/imageProxy.ts` — sends all selected images + query in a single `LanguageModelChatMessage`, letting the vision model see them together.
- Refactored shared logic into `sendToVisionModel()` helper to avoid duplication.

**3. Dynamic routing in provider**
- Updated `_handleInterceptedToolCall()` to detect which tool was called and route accordingly:
  - `ask_image` → `callVisionModel()` (single image)
  - `ask_with_multi_image` → `callVisionModelMulti()` (multiple images)
- Round messages now use `intercepted.name` dynamically so both tools work correctly in assistant/tool_call messages.

**4. Interception & injection**
- `commonApi.ts`: both `ask_image` and `ask_with_multi_image` are intercepted (not sent to VS Code UI) and stored in `interceptedToolCall`.
- `openaiApi.ts` + `anthropicApi.ts`: both tool definitions injected when images are present.

### Files Changed

| File | Change |
|------|--------|
| `src/vision/types.ts` | Add ASK_WITH_MULTI_IMAGE_TOOL_DEF, _NAME, update InterceptedToolCall args |
| `src/vision/imageProxy.ts` | Add callVisionModelMulti(), refactor into sendToVisionModel() |
| `src/commonApi.ts` | Intercept ask_with_multi_image alongside ask_image |
| `src/openai/openaiApi.ts` | Inject ask_with_multi_image when _localImages.length >= 2 |
| `src/anthropic/anthropicApi.ts` | Inject ask_with_multi_image when _localImages.length >= 2 |
| `src/provider.ts` | Dynamic routing per tool, dynamic tool name in round messages |