### PR TITLE
fix: correct commit message model config and thinking disabled handling

### DIFF
--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -269,13 +269,14 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		}
 
 		// Add thinking mode (Anthropic-compatible format)
-		// Only set when thinking is enabled; omit when disabled to avoid sending invalid values
 		if (um?.enable_thinking === true) {
 			if (um?.reasoning_effort === 'adaptive') {
 				rb.thinking = { type: "adaptive" };
 			} else {
 				rb.thinking = { type: "enabled", budget_tokens: 8192 };
 			}
+		} else {
+			rb.thinking = { type: "disabled" };
 		}
 
 		// Add tools configuration

--- a/src/gitCommit/commitMessageGenerator.ts
+++ b/src/gitCommit/commitMessageGenerator.ts
@@ -221,7 +221,15 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
 
         // Use model from config or default to deepseek-v4-flash
         const commitModelId = config.get<string>("opencodego.commitModel", "deepseek-v4-flash");
-        const selectedModel: OpenCodeGoModelItem = { id: commitModelId, owned_by: "opencode" };
+        // Fetch full model config (apiMode, max_completion_tokens, extra, etc.)
+        const selectedModel: OpenCodeGoModelItem = getBuiltInModelConfig(commitModelId) ?? { id: commitModelId, owned_by: "opencode" };
+        // Commit messages are simple tasks — disable thinking to speed up generation.
+        selectedModel.enable_thinking = false;
+        selectedModel.reasoning_effort = "high";
+        // Cap max_completion_tokens to avoid proxy 500 errors with oversized values
+        if (selectedModel.max_completion_tokens && selectedModel.max_completion_tokens > 8192) {
+            selectedModel.max_completion_tokens = 8192;
+        }
         modelId = selectedModel.id;
         logger.info("commit.start", { modelId });
 

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -277,7 +277,7 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
                 }
             }
         } else {
-            rb.thinking = { type: false };
+            rb.thinking = { type: "disabled" };
         }
 
         // OpenRouter/OpenCode Go reasoning configuration


### PR DESCRIPTION
## Summary

This PR fixes two bugs related to commit message generation and thinking mode handling.

### Bug 1: Incomplete model config for commit message generation

**Before:** `commitMessageGenerator.ts` creates a minimal `{ id, owned_by }` object for the commit model, missing critical fields like `apiMode`, `max_completion_tokens`, and `extra`.

**After:** Uses `getBuiltInModelConfig()` to get the full model configuration, then overrides thinking to disabled and caps `max_completion_tokens` to 8192 (commit messages don't need deep reasoning).

**Impact:** Commit message generation now works correctly with all built-in models (DeepSeek, GLM, Kimi, Qwen, MiniMax, etc.) — not just the default DeepSeek.

### Bug 2: Wrong thinking disabled format

Both `openaiApi.ts` and `anthropicApi.ts` had incorrect handling when thinking was disabled:

- **OpenAI mode:** Sent `{ type: false }` → Changed to `{ type: "disabled" }` (DeepSeek/Qwen API requires string, not boolean)
- **Anthropic mode:** Omitted the thinking field entirely → Now explicitly sends `{ type: "disabled" }` (Qwen Anthropic endpoint requires explicit declaration)

**This also fixes the chat path** when a user manually selects "Disable Thinking" for a model.

### Changes

| File | Change |
|------|--------|
| `src/gitCommit/commitMessageGenerator.ts` | Use `getBuiltInModelConfig()` + disable thinking + cap max tokens |
| `src/openai/openaiApi.ts` | `thinking: { type: false }` → `thinking: { type: "disabled" }` |
| `src/anthropic/anthropicApi.ts` | Add `else { thinking: { type: "disabled" } }` branch |
