### PR TITLE
fix: update kimi-k2.7-code display name and force temperature=1

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -48,7 +48,7 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     // { baseId: "kimi-k2.6", displayName: "Kimi K2.6", vision: true, thinkingMode: "switchable", contextLength: 262144, maxTokens: 16384 },
     { baseId: "kimi-k2.5", displayName: "Kimi K2.5", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 16384 },
     { baseId: "kimi-k2.6", displayName: "Kimi K2.6", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 16384 },
-    { baseId: "kimi-k2.7-code", displayName: "Kimi K2.7", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 16384 },
+    { baseId: "kimi-k2.7-code", displayName: "Kimi K2.7 Code", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 16384 },
 
     // ── DeepSeek series ── 官方文档: 1M context, 384K max output ──
     { baseId: "deepseek-v4-pro", displayName: "DeepSeek V4 Pro", vision: false, thinkingMode: "switchable", defaultReasoningEffort: "max", supportedReasoningEfforts: ["high", "max"], contextLength: 1000000, maxTokens: 393216 },

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -248,6 +248,11 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
             rb.temperature = um.temperature;
         }
 
+        // Moonshot AI Kimi K2.7 only accepts temperature=1
+        if (um?.id === "kimi-k2.7-code") {
+            rb.temperature = 1;
+        }
+
         // top_p
         if (um?.top_p !== undefined && um.top_p !== null) {
             rb.top_p = um.top_p;


### PR DESCRIPTION
## Summary

Small follow-up fixes for the Kimi K2.7 model (kimi-k2.7-code) added in PR #48.

## Changes

1. Display name update (src/models.ts)
   - Changed from Kimi K2.7 to Kimi K2.7 Code for clearer identification in the model picker.

2. Temperature fix (src/openai/openaiApi.ts)
   - Moonshot AI's Kimi K2.7 rejects requests when temperature is not exactly 1.
   - This override ensures temperature: 1 is always sent for kimi-k2.7-code, regardless of user presets or custom settings.

## Files Changed

| File | Change |
|------|--------|
| src/models.ts | Rename display name to Kimi K2.7 Code |
| src/openai/openaiApi.ts | Force temperature: 1 for kimi-k2.7-code |

## Verification

- [x] TypeScript compilation passes (npm run compile)
- [x] Tested against live API - requests now succeed

Agent: Kimi K2.6
