### PR TITLE
fix: disable temperature for Kimi K3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@
 | 系列 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 |
 |------|---------|------|----------------|----------|
 | GLM | `glm-5.2`, `glm-5.1`, `glm-5` | ❌ | `禁用思考` / `高` / `最大` (5.2)² / `思考`（5.1/5 不支持思考切换） | OpenAI |
-| Kimi | `kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code`¹ | ✅ | `思考`（不支持思考切换） | OpenAI |
+| Kimi | `kimi-k3`¹, `kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code`¹ | ✅ | `禁用思考` / `思考`（K3）；`思考`（K2.x，不支持思考切换） | OpenAI |
 
-> ¹ `kimi-k2.7-code` 不支持设置 Temperature 参数。  
+> ¹ `kimi-k3` 和 `kimi-k2.7-code` 不支持设置 Temperature/Top-p 参数。
 > ² GLM-5.2 支持通过 reasoning_effort 设置 thinking 强度 (high/max)，GLM-5.1/GLM-5 不支持 thinking 切换。
 | DeepSeek | `deepseek-v4-pro`, `deepseek-v4-flash` | ❌ | `禁用思考` / `高` / `极高` | OpenAI |
 | MiMo | `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2.5-pro`, `mimo-v2.5` | mimo-v2-omni ✅ | `禁用思考` / `思考` | OpenAI |

--- a/src/models.ts
+++ b/src/models.ts
@@ -49,9 +49,10 @@ const BUILT_IN_MODELS: BuiltInModelDef[] = [
     { baseId: "glm-5.1", displayName: "GLM-5.1", vision: false, thinkingMode: "always", contextLength: 200000, maxTokens: 131072 },
     { baseId: "glm-5", displayName: "GLM-5", vision: false, thinkingMode: "always", contextLength: 200000, maxTokens: 131072 },
 
-    // ── Kimi series ── Moonshot AI, 官方文档: 256K context (262144 tokens) ──
+    // ── Kimi series ── K3: 1M context / 128K output; K2.x: 256K context ──
     // { baseId: "kimi-k2.5", displayName: "Kimi K2.5", vision: true, thinkingMode: "switchable", contextLength: 262144, maxTokens: 16384 },
     // { baseId: "kimi-k2.6", displayName: "Kimi K2.6", vision: true, thinkingMode: "switchable", contextLength: 262144, maxTokens: 16384 },
+    { baseId: "kimi-k3", displayName: "Kimi K3", vision: true, thinkingMode: "switchable", supportsTemperature: false, contextLength: 1048576, maxTokens: 131072 },
     { baseId: "kimi-k2.5", displayName: "Kimi K2.5", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 16384 },
     { baseId: "kimi-k2.6", displayName: "Kimi K2.6", vision: true, thinkingMode: "always", contextLength: 262144, maxTokens: 16384 },
     { baseId: "kimi-k2.7-code", displayName: "Kimi K2.7 Code", vision: true, thinkingMode: "always", supportsTemperature: false, contextLength: 262144, maxTokens: 16384 },


### PR DESCRIPTION
## Summary

- Register `kimi-k3` as a built-in model.
- Set `supportsTemperature: false` for Kimi K3.
- Prevent `temperature` and `top_p` from being sent for this model.
- Preserve temperature presets and custom values for all other supported models.

## Background

Kimi K3 was previously handled as an auto-discovered model and was assumed to support temperature configuration.

As reported in #63, requests containing `temperature: 0` return a `400 Bad Request`, while the same request succeeds when the parameter is omitted.

The provider already supports model-specific temperature capability flags, so this change marks Kimi K3 as unsupported instead of changing the global default behavior.

## Validation

- `npm run compile`
- `npm run lint` — 0 errors
- Confirmed the branch contains one commit and only the intended files

Closes #63