### PR TITLE
feat: Dynamic model discovery, security and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ Thumbs.db
 
 # Logs
 *.log
+
+# Temp files
+*.tmp
+temp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@
 | 能力 | 说明 |
 |------|------|
 | **Chat 模型提供商** | 实现 `LanguageModelChatProvider` 接口，向 VS Code 注册为 `opencodego` 厂商 |
-| **多模型支持** | 内置 17 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（8 个）。支持自动模型发现：开启后从 API 获取模型列表，自动过滤不可用模型并发现新增模型 |
+| **多模型支持** | 内置 17 个模型定义，覆盖 6 大模型系列，统一通过推理强度选择器切换思考模式。可选开启 OpenCode Zen 免费模型（动态发现，通过 `-free` 后缀过滤）。支持自动模型发现：开启后从 API 获取模型列表，自动过滤不可用模型并发现新增模型 |
 | **自动模型发现** | 通过 `opencodego.enableAutoModelDiscovery` 配置（默认开启）。启动时从 `/zen/go/v1/models` 获取当前可用模型 ID 列表，过滤内置模型列表（不可用模型自动隐藏）。新增模型从 `models.dev` 数据库获取元数据（上下文长度、视觉能力、工具调用、推理能力等）并自动添加，`thinkingMode` 从 `reasoning` 字段推断（支持推理→switchable，不支持→always）。API 不可用时静默回退到全量内置列表。内存缓存（5 分钟 TTL） |
-| **OpenCode Zen 免费模型** | 通过设置开关启用，从 Zen API 获取模型列表并过滤出 6 个免费模型（Big Pickle、DeepSeek V4 Flash、MiniMax M3、MiniMax M2.5、Ring 2.6 1T、Nemotron 3 Super），以 `OpenCode Zen` 标识追加到模型选择器。支持内存缓存（5 分钟 TTL），API 不可用时静默降级 |
+| **OpenCode Zen 免费模型** | 通过设置开关启用，从 Zen API 获取模型列表并过滤出 `-free` 后缀的免费模型，以 `OpenCode Zen` 标识追加到模型选择器。元数据从 `ZEN_MODEL_OVERRIDES` > models.dev > 保守默认值合并。支持内存缓存（5 分钟 TTL），API 不可用时返回空（无降级硬编码列表） |
 | **双 API 模式** | 同时支持 **OpenAI 兼容格式** (`/chat/completions`) 和 **Anthropic 格式** (`/v1/messages`) |
 | **流式推理** | 支持 SSE (Server-Sent Events) 流式响应，实时输出文本和工具调用 |
 | **Thinking/推理** | 支持模型的推理过程展示 ("thinking" 状态)，包括 XML think 块解析 |
@@ -46,6 +46,7 @@
 | **重试机制** | 可配置的指数退避重试策略，应对网络抖动和限流 (429) |
 | **请求延迟** | 可配置的请求间隔延迟，避免触发 API 限流 |
 | **超时控制** | 可配置的请求超时时间（默认 10 分钟） |
+| **HTTP 安全检查** | 通过 `opencodego.httpAllowInsecure` 配置（默认 false）控制；开启后跳过 Base URL 协议安全检查，允许将 HTTP 用于本地/私有网络地址之外的请求 |
 | **立即取消** | 取消请求时通过 `reader.cancel()` 立即中断流式读取，停止后台接收 |
 | **视觉代理配置** | 支持通过设置 `opencodego.visionProxyModel`、`opencodego.visionProxyThinking` 配置图片代理所使用的视觉模型和思考模式。`opencodego.visionProxyThinking` 默认关闭，关闭时内部请求通过 `modelOptions.thinking={ type: false }` / `reasoning_effort="disabled"` 禁用视觉模型思考，最终 OpenAI 兼容请求体发送 `thinking: { type: false }` |
 | **安装欢迎页 (Walkthrough)** | 首次安装且未配置 API Key 时自动打开引导向导，指引用户设置 API Key 和打开语言模型管理器。包含 3 个步骤：设置 API Key、显示模型、高级设置。通过 `onStartupFinished` 激活事件确保在 VS Code 启动后立即检测 |
@@ -71,16 +72,9 @@
 
 #### OpenCode Zen 免费模型（可选）
 
-通过设置 `opencodego.enableZenFreeModels`（默认关闭）启用，从 Zen API 获取模型列表并与硬编码 ID 过滤后加入模型选择器。
+通过设置 `opencodego.enableZenFreeModels`（默认关闭）启用，从 Zen API 获取模型列表并过滤出 `-free` 后缀的免费模型，以 `OpenCode Zen` 标识追加到模型选择器。
 
-| 显示名 | 模型 ID | 视觉 | 推理强度选择器 | API 格式 | 备注 |
-|--------|---------|------|----------------|----------|------|
-| Zen/Big Pickle Free | `big-pickle` | ❌ | `思考`（不支持思考切换） | OpenAI | 限时免费 |
-| Zen/DeepSeek V4 Flash Free | `deepseek-v4-flash-free` | ❌ | `禁用思考` / `高` / `极高` | OpenAI | 限时免费 |
-| Zen/MiniMax M3 Free | `minimax-m3-free` | ✅ | `禁用思考` / `自适应` | OpenAI | 限时免费；1M 上下文，仅支持 `adaptive` / `disabled` 思考模式 |
-| Zen/MiniMax M2.5 Free | `minimax-m2.5-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
-| Zen/Ring 2.6 1T Free | `ring-2.6-1t-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
-| Zen/Nemotron 3 Super Free | `nemotron-3-super-free` | ❌ | `禁用思考` / `思考` | OpenAI | 限时免费 |
+> Zen 免费模型动态发现，模型列表取决于 API 可用性。元数据合并策略：`ZEN_MODEL_OVERRIDES` > models.dev > 保守默认值。常见发现的模型包括但不限于：`big-pickle`、`deepseek-v4-flash-free`、`minimax-m3-free`、`minimax-m2.5-free`、`ring-2.6-1t-free`、`nemotron-3-super-free` 等。
 
 在模型选择器中，内置模型归入 `OpenCode Go` 分组（`family="OpenCodeGo"`），Zen 免费模型归入 `OpenCode Zen` 分组（`family="OpenCode Zen"`）以作区分。
 
@@ -426,14 +420,14 @@ src/
 | `types.ts` | ~95 | `OpenCodeGoModelItem`, `ModelPreset`, `ModelsResponse`, `RetryConfig` 等类型 |
 | `apiModelList.ts` | ~80 | API 模型列表获取：从 `/zen/go/v1/models` 拉取可用模型 ID，5 分钟缓存，静默降级 |
 | `modelsDev.ts` | ~130 | models.dev 元数据拉取与查询：从 `models.dev/models.json` 下载并索引模型规格，支持短 ID 匹配，1 小时缓存 |
-| `commonApi.ts` | ~462 | `CommonApi<TMessage,TRequestBody>` 抽象基类（图片存储、工具调用拦截） |
-| `provideModel.ts` | ~130 | 模型信息提供函数（含自动发现）：过滤内置模型、从 API 和 models.dev 自动发现新增模型 |
+| `commonApi.ts` | ~467 | `CommonApi<TMessage,TRequestBody>` 抽象基类（图片存储、工具调用拦截、User-Agent 配置读取） |
+| `provideModel.ts` | ~266 | 模型信息提供函数（含自动发现、`deduceApiMode()` 从 models.dev 推断 apiMode）：过滤内置模型、从 API 和 models.dev 自动发现新增模型 |
 | `provideToken.ts` | ~100 | Token 用量计算 |
 | `utils.ts` | ~285 | 工具函数 (重试、角色映射、工具转换等) |
 | `statusBar.ts` | ~140 | 状态栏创建、更新、累计计数器 |
 | `logger.ts` | ~55 | 日志输出 (LogOutputChannel) |
 | `localize.ts` | ~109 | 中英文国际化 |
-| `versionManager.ts` | ~35 | 扩展版本信息 |
+| `versionManager.ts` | ~35 | 扩展版本信息（使用正确扩展 ID `OnesoftQwQ.opencode-go-copilot-provider`） |
 | `openai/openaiApi.ts` | ~613 | OpenAI 格式 API 实现 (消息转换/请求构建/流式处理/图片代理) |
 | `openai/openaiTypes.ts` | ~75 | OpenAI 类型定义 |
 | `anthropic/anthropicApi.ts` | ~535 | Anthropic 格式 API 实现 (消息转换/请求构建/流式处理/图片代理) |
@@ -446,7 +440,7 @@ src/
 | `vision/historyCodec.ts` | ~150 | 视觉工具历史 DataPart 的 MIME、数据校验/编解码，以及 OpenAI/Anthropic 标准 tool call + tool result 消息重建；由 `scripts/test-vision-history.mjs` 做编解码和双 API 转换器顺序闭环测试 |
 | `vision/historyPart.ts` | ~28 | 创建和解析 `application/vnd.opencodego.vision-tool-history+json` DataPart；测试脚本使用 VS Code 最小运行时桩验证下一轮消息转换 |
 | `vision/imageProxy.ts` | ~95 | 图片代理核心：调用视觉模型描述图片（`callVisionModel`/`callVisionModelMulti`），支持 thinking 模式配置和文本流式转发 |
-| `zen/zenModels.ts` | ~256 | Zen 免费模型定义、API 拉取、缓存管理、配置查询（所有模型声明 `imageInput: true`） |
+| `zen/zenModels.ts` | ~282 | Zen 免费模型动态发现（通过 `-free` 后缀过滤）、`ZEN_MODEL_OVERRIDES` 最小覆盖映射、`deduceApiModeFromFamily()` 辅助函数、缓存管理、配置查询（所有模型声明 `imageInput: true`，无硬编码 ID 列表） |
 
 ---
 
@@ -487,7 +481,7 @@ src/
 计算文本或消息的 Token 数量。委托给 `countMessageTokens()`。
 
 #### `provideLanguageModelChatResponse(model, messages, options, progress, token): Promise<void>`
-核心方法：处理聊天请求，流式返回响应。包括模型配置获取（内置模型 → Zen 模型回退 → 自动发现回退）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析、图片代理拦截处理和错误处理。错误处理区分三种情况：用户取消（直接重新抛出原始错误）、超时（友好超时提示）、连接被终止（友好终止提示）。
+核心方法：处理聊天请求，流式返回响应。包括模型配置获取（内置模型 → Zen 模型回退 → 自动发现回退）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析、图片代理拦截处理和错误处理。错误处理区分三种情况：用户取消（直接重新抛出原始错误）、超时（友好超时提示）、连接被终止（友好终止提示）。内置模型配置通过 `{ ...um }` 浅拷贝后再修改 thinking/temperature，防止并发会话间互相泄漏设置。
 
 #### `private async _handleInterceptedToolCall(params): Promise<void>`
 处理图片代理拦截。循环处理最多 `opencodego.visionMaxRounds` 轮（默认 5）。每轮检测 API 实例的 `interceptedToolCall`，发出 thinking 块显示“正在根据图片提问：[问题]”，关闭 thinking 块后视觉模型输出以普通文本流式显示，并立即输出一个 `application/vnd.opencodego.vision-tool-history+json` DataPart 保存调用 ID、参数、视觉结果和 OpenAI 模式所需的 `reasoning_content`。单图调用 `callVisionModel()`，多图调用 `callVisionModelMulti()`，构建本轮 API 请求（追加 assistant tool_call + tool result），注入 VS Code 原生工具 + ask_image（+ ask_with_multi_image 当 >=2 图时）供模型继续使用，保留 temperature/reasoning_effort 等原始参数，DeepSeek 兼容注入 `reasoning_content`。模型不再调用 ask_image/ask_with_multi_image 时退出循环。
@@ -502,6 +496,9 @@ src/
 
 #### `private async ensureApiKey(): Promise<string | undefined>`
 确保 API Key 存在于 SecretStorage 中，缺失时弹出输入框提示用户输入。
+
+#### Base URL HTTP 安全检查
+在发送请求前验证 base URL：拒绝非 HTTP 协议；针对 `http:` 协议仅允许 localhost、127.0.0.1、::1、192.168.\*、10.\*、0.0.0.0 等本地/私有网络地址，远程端点强制使用 HTTPS。可通过 `opencodego.httpAllowInsecure` 配置（默认 false）跳过整个 HTTP 协议安全检查。
 
 ---
 
@@ -660,14 +657,14 @@ API 实现的抽象基类。
 处理普通文本内容，发射到进度报告器。
 
 #### `static prepareHeaders(apiKey, apiMode, customHeaders?): Record<string, string>`
-准备 HTTP 请求头。Anthropic 模式使用 `x-api-key`，OpenAI 模式使用 `Bearer` 令牌。
+准备 HTTP 请求头。读取 `opencodego.userAgent` 配置设置 User-Agent（回退到 `VersionManager.getUserAgent()`）。Anthropic 模式使用 `x-api-key`，OpenAI 模式使用 `Bearer` 令牌。
 
 ---
 
 ### 4.6 `src/apiModelList.ts`
 
 #### `getApiModelIds(apiKey): Promise<Set<string>>`
-从 `/zen/go/v1/models` 拉取可用模型 ID 列表并返回 Set。使用内存缓存（5 分钟 TTL），API 不可用时返回空 Set 或上次缓存。导出 `isApiFetchSuccessful()` 检查上次请求是否成功。
+从 `/zen/go/v1/models` 拉取可用模型 ID 列表并返回 Set。使用内存缓存（5 分钟 TTL），API 不可用时返回空 Set 或上次缓存。内部 `fetchApiModelList()` 使用 10 秒 `AbortSignal.timeout(10000)`，超时后记录警告并抛出普通 `Error`（非 AbortError）以保留调用方缓存。导出 `isApiFetchSuccessful()` 检查上次请求是否成功。
 
 #### `isApiFetchSuccessful(): boolean`
 返回最近一次 API 模型列表拉取是否成功。用于模型提供者决定是否应用 API 过滤。
@@ -680,20 +677,26 @@ API 实现的抽象基类。
 `{ id, name?, family?, reasoning?, tool_call?, structured_output?, temperature?, attachment?, modalities?, limit? }` — models.dev 数据库中单个模型条目的接口。
 
 #### `ensureModelsDevLoaded(): Promise<void>`
-从 `https://models.dev/models.json` 下载完整模型目录并构建内存索引（完整 ID → 条目 + 短 ID → 条目）。1 小时缓存 TTL，失败时静默保留旧缓存。首次无缓存时初始化为空 Map。
+从 `https://models.dev/models.json` 下载完整模型目录并构建内存索引（完整 ID → 条目 + 短 ID → 条目）。内部 `fetchModelsDevCatalog()` 使用 10 秒 `AbortSignal.timeout(10000)`，超时后记录警告并抛出普通 `Error`（非 AbortError）以保留现有缓存。1 小时缓存 TTL，失败时静默保留旧缓存。首次无缓存时初始化为空 Map。
 
 #### `lookupModelDevEntry(apiModelId): ModelsDevEntry | undefined`
 按 API 模型 ID 查找 models.dev 元数据。匹配策略：1) 完整 models.dev ID 精确匹配，2) 短 ID（斜杠后最后一段）匹配，3) 后缀匹配。
+
+#### `deduceApiModeFromFamily(modelId, entry?)`
+根据模型 ID 和可选的 models.dev 条目推断 API 格式（`"openai"` 或 `"anthropic"`）。使用 family 启发式判断：Claude/Anthropic 系列、Qwen 3.6/3.7 系列（匹配 `/qwen[\s-]*3\.[67]/i`）、Gemma 系列 → Anthropic；其余 → OpenAI。被 `storeAutoDiscoveredConfig()` 调用于确定自动发现模型的 apiMode。
 
 ---
 
 ### 4.10 `src/provideModel.ts`
 
 #### `prepareLanguageModelChatInformation(options, _token, _secrets): Promise<LanguageModelChatInformation[]>`
-获取模型信息列表。默认使用硬编码的内置模型列表（委托 `getBuiltInModelInfos()`）。当配置 `opencodego.enableAutoModelDiscovery` 开启时（默认），从 API 获取可用模型 ID 列表，过滤内置模型（仅保留 API 中存在的模型），并从 models.dev 自动发现新增模型（默认 `thinkingMode="always"`）。API 不可用时静默回退到全量内置列表。当配置 `opencodego.enableZenFreeModels` 开启时，额外调用 `getZenFreeModelInfos()` 获取 Zen 免费模型并追加到列表末尾。
+获取模型信息列表。默认使用硬编码的内置模型列表（委托 `getBuiltInModelInfos()`）。当配置 `opencodego.enableAutoModelDiscovery` 开启时（默认），从 API 获取可用模型 ID 列表，过滤内置模型（仅保留 API 中存在的模型），并从 models.dev 自动发现新增模型（默认 `thinkingMode="always"`）。自动发现前调用 `_autoDiscoveredConfigs.clear()` 清空旧条目。API 不可用时静默回退到全量内置列表。当配置 `opencodego.enableZenFreeModels` 开启时，额外调用 `getZenFreeModelInfos()` 获取 Zen 免费模型并追加到列表末尾。
+
+#### `deduceApiMode(modelId, entry?)`
+根据模型 ID 和可选的 models.dev 条目推断 API 格式（`"openai"` 或 `"anthropic"`）。使用 family 启发式判断：Claude/Anthropic 系列、Qwen 3.6/3.7 系列、Gemma 系列 → Anthropic；其余 → OpenAI。被 `storeAutoDiscoveredConfig()` 调用于确定自动发现模型的 apiMode。
 
 #### `getAutoDiscoveredModelConfig(modelId): OpenCodeGoModelItem | undefined`
-返回之前自动发现的模型配置。由 `provider.ts` 在 `getBuiltInModelConfig()` 和 `getZenFreeModelConfig()` 都返回 undefined 时作为第三回退调用。
+返回之前自动发现的模型配置（返回 `{ ...config }` 浅拷贝，防止调用方突变共享缓存）。由 `provider.ts` 在 `getBuiltInModelConfig()` 和 `getZenFreeModelConfig()` 都返回 undefined 时作为第三回调调用。
 
 ---
 
@@ -881,6 +884,9 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 #### `l10nFormat(template, ...args): string`
 格式化本地化字符串，替换 `{0}`, `{1}` 等占位符。
 
+新增本地化键：
+- `"Plain HTTP is only allowed for localhost or private network addresses. Use HTTPS for remote endpoints."` — Base URL 安全验证错误提示
+
 ---
 
 ### 4.12 `src/versionManager.ts`
@@ -889,8 +895,8 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 
 | 静态方法 | 说明 |
 |----------|------|
-| `getVersion(): string` | 获取扩展版本号（从 `package.json` 读取） |
-| `getUserAgent(): string` | 构建 User-Agent 字符串 |
+| `getVersion(): string` | 获取扩展版本号（从 `package.json` 读取，使用正确扩展 ID `OnesoftQwQ.opencode-go-copilot-provider` 而非旧值 `my-company.opencode-go-copilot`） |
+| `getUserAgent(): string` | 构建 User-Agent 字符串（被 `CommonApi.prepareHeaders()` 用作回退 User-Agent） |
 | `getClientInfo(): { name, version, author }` | 获取客户端信息 |
 
 ---
@@ -940,7 +946,7 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 将 VS Code 消息转换为 OpenAI 格式。支持文本、图片、工具调用、工具结果、推理内容的消息转换。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。同时递归扫描 `LanguageModelToolResultPart.content` 中的图片一并存入（确保通过工具返回的图片也能被 `ask_image` 代理识别）。
 
 #### `prepareRequestBody(rb, um?, options?): Record<string, unknown>`
-构建 OpenAI 请求体。设置 temperature、top_p、max_tokens、reasoning_effort（adaptive 模式时跳过）、thinking 模式（支持 `{ type: "enabled" }`、`{ type: "adaptive" }` 和关闭用 `{ type: false }`）、stop、tools、tool_choice 以及各种惩罚参数和 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。
+构建 OpenAI 请求体。设置 temperature、top_p、max_tokens、reasoning_effort（adaptive 模式时跳过）、thinking 模式（支持 `{ type: "enabled" }`、`{ type: "adaptive" }` 和关闭用 `{ type: false }`）、stop、tools、tool_choice 以及各种惩罚参数和 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。Extra 参数合并前过滤保留键（`model`, `messages`, `stream`, `temperature`, `top_p`, `max_tokens`, `max_completion_tokens`, `tools`, `tool_choice`, `stop`, `reasoning_effort`, `thinking`, `top_k`, `min_p`, `frequency_penalty`, `presence_penalty`, `repetition_penalty`, `stream_options`, `reasoning` 等），冲突时 `logger.warn()` 记录。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
 处理 OpenAI SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，处理 `[DONE]` 标记，解析 usage 用量信息，委托 `processDelta()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。在 `finally` 块中 dispose 该回调，防止多次调用 `processStreamingResponse` 时回调累积。
@@ -1004,7 +1010,7 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 将 VS Code 消息转换为 Anthropic 格式。系统消息提取到 `_systemContent`。支持文本、图片、工具使用、工具结果、推理内容。使用 `content` 块数组格式。modelConfig 新增 `vision` 字段，非视觉模型时自动替换图片为文本引用并存储图片数据。同时递归扫描 `AnthropicToolResultBlock.content` 中的图片一并存入（确保通过工具返回的图片也能被 `ask_image` 代理识别）。
 
 #### `prepareRequestBody(rb, um?, options?): AnthropicRequestBody`
-构建 Anthropic 请求体。设置 max_tokens、system、temperature、top_p、top_k、thinking 模式（支持 `{ type: "enabled" }`、`{ type: "adaptive" }` 和 `{ type: "disabled" }`）、tools（转换为 Anthropic 格式）、tool_choice（auto/any/none）以及 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。
+构建 Anthropic 请求体。设置 max_tokens、system、temperature、top_p、top_k、thinking 模式（支持 `{ type: "enabled" }`、`{ type: "adaptive" }` 和 `{ type: "disabled" }`）、tools（转换为 Anthropic 格式）、tool_choice（auto/any/none）以及 extra 参数。非视觉模型且存在图片时自动注入 `ask_image` 工具定义。Extra 参数合并前过滤保留键（`model`, `messages`, `stream` 等），冲突时 `logger.warn()` 记录。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
 处理 Anthropic SSE 流式响应。逐行解析 `data:` 前缀的 SSE 事件，委托 `processAnthropicChunk()`。注册取消回调：`token.onCancellationRequested` 时调用 `reader.cancel()` 立即中断流式读取。在 `finally` 块中 dispose 该回调，防止多次调用 `processStreamingResponse` 时回调累积。
@@ -1051,7 +1057,7 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 确保 API Key 存在。
 
 #### `performCommitMsgGeneration(secrets, gitDiff, inputBox, repoPath?): Promise<void>`
-核心生成逻辑。构建 prompt（含自定义提示词、最近提交风格、用户输入、diff 内容），支持 `auto` 语言模式（由模型根据历史 commit 风格自动推断），创建 API 实例，流式输出提交消息到 InputBox。支持通过配置 `opencodego.commitIncludeCommitDiff` 控制风格参考中是否包含历史提交的实际代码变更（默认关闭）。支持通过配置 `opencodego.commitAttachContextFiles`（默认开启）控制是否将仓库根目录的 `AGENTS.md` 和 `README.md` 内容附加到 prompt 中作为额外上下文。
+核心生成逻辑。构建 prompt（含自定义提示词、最近提交风格、用户输入、diff 内容），支持 `auto` 语言模式（由模型根据历史 commit 风格自动推断），创建 API 实例，流式输出提交消息到 InputBox。支持通过配置 `opencodego.commitIncludeCommitDiff` 控制风格参考中是否包含历史提交的实际代码变更（默认关闭）。支持通过配置 `opencodego.commitAttachContextFiles`（默认开启）控制是否将仓库根目录的 `AGENTS.md` 和 `README.md` 内容附加到 prompt 中作为额外上下文。在选择模型配置后浅拷贝（`{ ...config }`）再修改 `enable_thinking` 和 `max_completion_tokens`，防止对共享的自动发现配置缓存的突变。
 
 #### `abortCommitGeneration(): void`
 中止提交消息生成。
@@ -1151,11 +1157,8 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 
 ### 4.21 `src/zen/zenModels.ts`
 
-#### `const ZEN_FREE_MODEL_IDS: readonly string[]`
-5 个硬编码的 Zen 免费模型 ID 数组：`big-pickle`、`deepseek-v4-flash-free`、`minimax-m2.5-free`、`ring-2.6-1t-free`、`nemotron-3-super-free`。
-
-#### `const ZEN_FREE_MODEL_METADATA`
-免费模型元数据映射，包含 `displayName`、`contextLength`、`vision`、`maxTokens` 字段。
+#### `const ZEN_MODEL_OVERRIDES`
+最小覆盖映射，为特定 Zen 免费模型提供非默认元数据值（如 `deepseek-v4-flash-free` 的 thinking 强度选项、`minimax-m3-free` 的 vision 和 apiMode 等）。合并优先级：`ZEN_MODEL_OVERRIDES` > models.dev > 保守默认值。
 
 #### `const ZEN_BASE_URL`
 Zen API 基础 URL：`https://opencode.ai/zen/v1/`。
@@ -1169,22 +1172,25 @@ Zen API 基础 URL：`https://opencode.ai/zen/v1/`。
 #### `let cacheTimestamp: number`
 缓存时间戳，用于判断缓存是否过期。
 
+#### `function deduceApiModeFromFamily(modelId, entry?)`
+根据模型 ID 和可选的 models.dev 条目推断 API 格式。复制 `provideModel.ts` 中 `deduceApiMode` 相同逻辑。使用 family 启发式判断：Claude/Anthropic 系列、Qwen 3.6/3.7 系列、Gemma 系列 → Anthropic；其余 → OpenAI。
+
 #### `async function fetchZenModelList(apiKey): Promise<string[]>`
-从 `https://opencode.ai/zen/v1/models` 拉取完整的模型 ID 列表。API 遵循 OpenAI `/v1/models` 格式，返回 `{ object: "list", data: [{ id, object, created, owned_by }] }`。
+从 `https://opencode.ai/zen/v1/models` 拉取完整的模型 ID 列表。API 遵循 OpenAI `/v1/models` 格式，返回 `{ object: "list", data: [{ id, object, created, owned_by }] }`。使用 `AbortController` 实现 10 秒超时（`setTimeout` + `controller.abort()`），超时后记录警告并抛出 `AbortError` 供调用方处理缓存回退。
 
 #### `function buildModelInfos(modelIds): LanguageModelChatInformation[]`
-根据模型 ID 列表构建 VS Code 模型信息数组。只包含在 `ZEN_FREE_MODEL_METADATA` 中有对应元数据的模型。每个模型注册为 `isUserSelectable: true`，带 `detail="OpenCode Zen"` 和基础版推理强度选择器（`禁用思考` / `思考`）。
+根据模型 ID 列表构建 VS Code 模型信息数组。对每个模型合并元数据：`ZEN_MODEL_OVERRIDES` > models.dev > 保守默认值（`thinkingMode="switchable"`、`contextLength=128000`、`maxTokens=4096`、`vision=false`）。switchable 模型包含 `disabled` 选项，always 模型不包含。
 
 #### `async function getZenFreeModelInfos(secrets): Promise<LanguageModelChatInformation[]>`
 获取 Zen 免费模型列表。流程：
 1. 检查缓存（5 分钟 TTL），有效则直接返回
-2. 获取 API Key，存在则调用 `fetchZenModelList()` 与 `ZEN_FREE_MODEL_IDS` 做交集过滤
-3. 拉取成功 → 更新缓存 → 返回过滤后的模型
-4. 拉取失败 → 使用过期缓存或全量硬编码列表（乐观降级）
-5. 无 API Key → 使用过期缓存或全量硬编码列表
+2. 获取 API Key，存在则调用 `fetchZenModelList()` 过滤出 `id.endsWith("-free")` 的模型
+3. 拉取成功 → 更新缓存 → 加载 models.dev 元数据 → 返回过滤后的模型
+4. 拉取失败 → 使用过期缓存（如有）
+5. 无 API Key 或无缓存 → 返回空数组（无降级硬编码列表）
 
 #### `function getZenFreeModelConfig(modelId): OpenCodeGoModelItem | undefined`
-按模型 ID 查找 Zen 免费模型配置。返回 `baseUrl: "https://opencode.ai/zen/v1/"`、`apiMode: "openai"`、`thinkingMode: "switchable"` 的模型配置对象。内置模型找不到时由 `provider.ts` 作为回退调用。
+按模型 ID 查找 Zen 免费模型配置。要求 `modelId.endsWith("-free")`，否则返回 undefined。元数据合并：`ZEN_MODEL_OVERRIDES` > models.dev > 保守默认值。使用 `deduceApiModeFromFamily()` 推断 apiMode。将 `ZEN_MODEL_OVERRIDES` 中的 `defaultReasoningEffort` 传播到返回配置的 `reasoning_effort` 字段。内置模型找不到时由 `provider.ts` 作为回退调用。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -351,6 +351,11 @@
 					"default": true,
 					"description": "%config.enableThirdPartyTokenIndicator.desc%"
 				},
+				"opencodego.httpAllowInsecure": {
+					"type": "boolean",
+					"default": false,
+					"description": "%opencodego.config.httpAllowInsecure%"
+				},
 				"opencodego.userAgent": {
 					"type": "string",
 					"default": "",

--- a/package.json
+++ b/package.json
@@ -309,6 +309,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "%config.enableThirdPartyTokenIndicator.desc%"
+				},
+				"opencodego.userAgent": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "%config.userAgent.desc%"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -196,6 +196,41 @@
 					"minimum": 10000,
 					"description": "%config.requestTimeout.desc%"
 				},
+				"opencodego.delay": {
+					"type": "number",
+					"default": 0,
+					"minimum": 0,
+					"markdownDescription": "%config.delay.desc%"
+				},
+				"opencodego.retry.enabled": {
+					"type": "boolean",
+					"default": true,
+					"description": "%config.retry.enabled.desc%"
+				},
+				"opencodego.retry.max_attempts": {
+					"type": "number",
+					"default": 3,
+					"minimum": 1,
+					"maximum": 10,
+					"description": "%config.retry.maxAttempts.desc%"
+				},
+				"opencodego.retry.interval_ms": {
+					"type": "number",
+					"default": 1000,
+					"minimum": 0,
+					"description": "%config.retry.intervalMs.desc%"
+				},
+				"opencodego.retry.status_codes": {
+					"type": "array",
+					"items": {
+						"type": "integer",
+						"minimum": 100,
+						"maximum": 599
+					},
+					"uniqueItems": true,
+					"default": [],
+					"description": "%config.retry.statusCodes.desc%"
+				},
 				"opencodego.recentCommitsCount": {
 					"type": "number",
 					"default": 10,
@@ -295,6 +330,12 @@
 					},
 					"description": "%config.modelPresets.desc%"
 				},
+				"opencodego.readFileLines": {
+					"type": "number",
+					"default": 0,
+					"minimum": 0,
+					"markdownDescription": "%config.readFileLines.desc%"
+				},
 				"opencodego.visionProxyModel": {
 					"type": "string",
 					"default": "qwen3.6-plus",
@@ -314,6 +355,13 @@
 					"type": "string",
 					"default": "",
 					"markdownDescription": "%config.userAgent.desc%"
+				},
+				"opencodego.visionMaxRounds": {
+					"type": "number",
+					"default": 5,
+					"minimum": 1,
+					"maximum": 20,
+					"markdownDescription": "%config.visionMaxRounds.desc%"
 				}
 			}
 		}

--- a/package.nls.json
+++ b/package.nls.json
@@ -51,6 +51,7 @@
 
 	"config.delay.desc": "Delay in milliseconds between consecutive API requests to avoid rate limiting. Set to 0 for no delay. Default: 0.",
 	"config.visionMaxRounds.desc": "Maximum number of vision proxy rounds for non-vision models using the `ask_image` tool to query images. Limits follow-up queries per request. Default: 5.",
+	"opencodego.config.httpAllowInsecure": "Allow plain HTTP connections to any server (insecure). When disabled, plain HTTP is only allowed for localhost and private network addresses.",
 	"config.readFileLines.desc": "Default number of lines for the `read_file` tool. When set to a positive value, the extension automatically adjusts `read_file` tool calls to read this many lines. Set to 0 for no adjustment. Default: 0.",
 	"config.retry.enabled.desc": "Enable automatic retry with exponential backoff for failed API requests. Default: true.",
 	"config.retry.maxAttempts.desc": "Maximum number of retry attempts for failed API requests. Default: 3.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -49,6 +49,14 @@
 	"config.enableThirdPartyTokenIndicator.desc": "Enable the Advanced Token indicator in the status bar. The native Copilot token indicator always shows. When this is enabled, the extension also shows an advanced token counter in the VS Code status bar. Default: true.",
 	"config.userAgent.desc": "Custom User-Agent header for API requests. Leave empty to use the default (`opencode-go-copilot/{version} VSCode/{vs_version}`). Useful for identifying your extension instance in server logs or when routing through proxies.",
 
+	"config.delay.desc": "Delay in milliseconds between consecutive API requests to avoid rate limiting. Set to 0 for no delay. Default: 0.",
+	"config.visionMaxRounds.desc": "Maximum number of vision proxy rounds for non-vision models using the `ask_image` tool to query images. Limits follow-up queries per request. Default: 5.",
+	"config.readFileLines.desc": "Default number of lines for the `read_file` tool. When set to a positive value, the extension automatically adjusts `read_file` tool calls to read this many lines. Set to 0 for no adjustment. Default: 0.",
+	"config.retry.enabled.desc": "Enable automatic retry with exponential backoff for failed API requests. Default: true.",
+	"config.retry.maxAttempts.desc": "Maximum number of retry attempts for failed API requests. Default: 3.",
+	"config.retry.intervalMs.desc": "Initial delay in milliseconds before the first retry attempt. Increases exponentially with each retry. Default: 1000.",
+	"config.retry.statusCodes.desc": "Additional HTTP status codes that trigger automatic retry beyond the default set (429, 500, 502, 503, 504). Default: [].",
+
 	"command.setModelPreset": "Set Model Temperature Preset",
 
 	"walkthrough.title": "OpenCode Go for Copilot Chat",

--- a/package.nls.json
+++ b/package.nls.json
@@ -47,6 +47,7 @@
 	"config.visionProxyModel.desc": "Vision model ID used by the ask_image tool to answer questions about attached images when the selected model does not support vision.",
 	"config.visionProxyThinking.desc": "Enable thinking/reasoning in the vision proxy model when answering image queries.",
 	"config.enableThirdPartyTokenIndicator.desc": "Enable the Advanced Token indicator in the status bar. The native Copilot token indicator always shows. When this is enabled, the extension also shows an advanced token counter in the VS Code status bar. Default: true.",
+	"config.userAgent.desc": "Custom User-Agent header for API requests. Leave empty to use the default (`opencode-go-copilot/{version} VSCode/{vs_version}`). Useful for identifying your extension instance in server logs or when routing through proxies.",
 
 	"command.setModelPreset": "Set Model Temperature Preset",
 

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -49,6 +49,14 @@
 	"config.enableThirdPartyTokenIndicator.desc": "启用高级 Token 指示器。Copilot 原生 Token 指示器始终保持开启。开启后，扩展还会在 VS Code 状态栏中显示高级Token计数器。默认: 开启。",
 	"config.userAgent.desc": "API 请求的自定义 User-Agent 头。留空则使用默认值 (`opencode-go-copilot/{version} VSCode/{vs_version}`)。可用于在服务器日志中识别您的扩展实例或配置代理路由。",
 
+	"config.delay.desc": "连续 API 请求之间的延迟时间（毫秒），用于避免触发频率限制。设为 0 表示不延迟。默认值: 0。",
+	"config.visionMaxRounds.desc": "非视觉模型使用 `ask_image` 工具查询图片时的最大视觉代理轮数。限制每次请求的后续追问次数。默认值: 5。",
+	"config.readFileLines.desc": "`read_file` 工具的默认读取行数。设为正值时，扩展会自动调整 `read_file` 工具调用的读取行数。设为 0 表示不调整。默认值: 0。",
+	"config.retry.enabled.desc": "启用失败 API 请求的自动重试（指数退避）。默认值: 开启。",
+	"config.retry.maxAttempts.desc": "失败 API 请求的最大重试次数。默认值: 3。",
+	"config.retry.intervalMs.desc": "首次重试前的初始延迟时间（毫秒）。每次重试后按指数递增。默认值: 1000。",
+	"config.retry.statusCodes.desc": "除默认状态码（429、500、502、503、504）之外，额外触发自动重试的 HTTP 状态码列表。默认值: []。",
+
 	"command.setModelPreset": "设置模型温度预设",
 
 	"walkthrough.title": "OpenCode Go for Copilot Chat",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -51,6 +51,7 @@
 
 	"config.delay.desc": "连续 API 请求之间的延迟时间（毫秒），用于避免触发频率限制。设为 0 表示不延迟。默认值: 0。",
 	"config.visionMaxRounds.desc": "非视觉模型使用 `ask_image` 工具查询图片时的最大视觉代理轮数。限制每次请求的后续追问次数。默认值: 5。",
+	"opencodego.config.httpAllowInsecure": "允许明文 HTTP 连接到任意服务器（不安全）。禁用时，明文 HTTP 仅允许 localhost 和私有网络地址。",
 	"config.readFileLines.desc": "`read_file` 工具的默认读取行数。设为正值时，扩展会自动调整 `read_file` 工具调用的读取行数。设为 0 表示不调整。默认值: 0。",
 	"config.retry.enabled.desc": "启用失败 API 请求的自动重试（指数退避）。默认值: 开启。",
 	"config.retry.maxAttempts.desc": "失败 API 请求的最大重试次数。默认值: 3。",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -47,6 +47,7 @@
 	"config.visionProxyModel.desc": "用于 ask_image 工具的视觉模型 ID。当所选模型不支持视觉时，该模型用于回答图片相关问题。",
 	"config.visionProxyThinking.desc": "在视觉代理模型回答图片查询时启用思考/推理功能。",
 	"config.enableThirdPartyTokenIndicator.desc": "启用高级 Token 指示器。Copilot 原生 Token 指示器始终保持开启。开启后，扩展还会在 VS Code 状态栏中显示高级Token计数器。默认: 开启。",
+	"config.userAgent.desc": "API 请求的自定义 User-Agent 头。留空则使用默认值 (`opencode-go-copilot/{version} VSCode/{vs_version}`)。可用于在服务器日志中识别您的扩展实例或配置代理路由。",
 
 	"command.setModelPreset": "设置模型温度预设",
 

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -346,6 +346,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		const ANTHROPIC_RESERVED_EXTRA_KEYS = new Set([
 			"model", "messages", "stream", "max_tokens", "system",
 			"temperature", "top_p", "top_k", "tools", "tool_choice",
+			"thinking", "stop_sequences",
 		]);
 		if (um?.extra && typeof um.extra === "object") {
 			for (const [key, value] of Object.entries(um.extra)) {

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -342,10 +342,17 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			}
 		}
 
-		// Process extra configuration parameters
+		// Process extra configuration parameters (filter reserved keys with warning)
+		const ANTHROPIC_RESERVED_EXTRA_KEYS = new Set([
+			"model", "messages", "stream", "max_tokens", "system",
+			"temperature", "top_p", "top_k", "tools", "tool_choice",
+		]);
 		if (um?.extra && typeof um.extra === "object") {
-			// Add all extra parameters directly to the request body
 			for (const [key, value] of Object.entries(um.extra)) {
+				if (ANTHROPIC_RESERVED_EXTRA_KEYS.has(key)) {
+					logger.warn("extra.conflict", { key, file: "anthropicApi" });
+					continue;
+				}
 				if (value !== undefined) {
 					(rb as unknown as Record<string, unknown>)[key] = value;
 				}

--- a/src/apiModelList.ts
+++ b/src/apiModelList.ts
@@ -6,6 +6,8 @@
  * Falls back to stale cache or an empty list on failure (silent degradation).
  */
 
+import { logger } from "./logger";
+
 const API_BASE_URL = "https://opencode.ai/zen/go/v1/";
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -21,18 +23,24 @@ let lastFetchSuccess = false;
  */
 async function fetchApiModelList(apiKey: string): Promise<string[]> {
     const url = `${API_BASE_URL.replace(/\/+$/, "")}/models`;
-    const response = await fetch(url, {
-        headers: {
-            Authorization: `Bearer ${apiKey}`,
-        },
-    });
-
-    if (!response.ok) {
-        throw new Error(`API model list error: [${response.status}] ${response.statusText}`);
+    try {
+        const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!response.ok) {
+            throw new Error(`API model list error: [${response.status}] ${response.statusText}`);
+        }
+        const body = (await response.json()) as { data?: Array<{ id: string }> };
+        return (body.data ?? []).map((m) => m.id);
+    } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+            logger.warn("apiModelList.fetch.timeout", { url });
+            // Throw a regular error so caller's catch block preserves stale cache
+            throw new Error(`Request timed out after 10000ms`);
+        }
+        throw err;
     }
-
-    const body = (await response.json()) as { data?: Array<{ id: string }> };
-    return (body.data ?? []).map((m) => m.id);
 }
 
 /**

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -10,6 +10,7 @@ import {
 } from "vscode";
 import { OpenCodeGoModelItem } from "./types";
 import { tryParseJSONObject } from "./utils";
+import { VersionManager } from "./versionManager";
 import type { InterceptedToolCall, StoredImage } from "./vision/types";
 import { ASK_IMAGE_TOOL_NAME, ASK_WITH_MULTI_IMAGE_TOOL_NAME } from "./vision/types";
 
@@ -434,9 +435,13 @@ export abstract class CommonApi<TMessage, TRequestBody> {
         apiMode: string,
         customHeaders?: Record<string, string>
     ): Record<string, string> {
+        const config = vscode.workspace.getConfiguration();
+        const customUserAgent = config.get<string>("opencodego.userAgent", "");
+        const userAgent = customUserAgent.trim() || VersionManager.getUserAgent();
+
         const headers: Record<string, string> = {
             "Content-Type": "application/json",
-            "User-Agent": "ai-sdk/openai-compatible/2.0.41 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.11",
+            "User-Agent": userAgent,
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate, br, zstd",
         };

--- a/src/gitCommit/commitMessageGenerator.ts
+++ b/src/gitCommit/commitMessageGenerator.ts
@@ -224,13 +224,15 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         // Use model from config or default to deepseek-v4-flash
         const commitModelId = config.get<string>("opencodego.commitModel", "deepseek-v4-flash");
         // Fetch full model config (apiMode, max_completion_tokens, extra, etc.)
-        const selectedModel: OpenCodeGoModelItem = getBuiltInModelConfig(commitModelId)
-            ?? await getZenFreeModelConfig(commitModelId)
-            ?? getAutoDiscoveredModelConfig(commitModelId)
-            ?? { id: commitModelId, owned_by: "opencode" };
+        // Shallow copy to avoid mutating the shared cached config (e.g. auto-discovered models).
+        const selectedModel: OpenCodeGoModelItem = {
+            ...(getBuiltInModelConfig(commitModelId)
+                ?? await getZenFreeModelConfig(commitModelId)
+                ?? getAutoDiscoveredModelConfig(commitModelId)
+                ?? { id: commitModelId, owned_by: "opencode" })
+        };
         // Commit messages are simple tasks — disable thinking to speed up generation.
         selectedModel.enable_thinking = false;
-        selectedModel.reasoning_effort = "high";
         // Cap max_completion_tokens to avoid proxy 500 errors with oversized values
         if (selectedModel.max_completion_tokens && selectedModel.max_completion_tokens > 8192) {
             selectedModel.max_completion_tokens = 8192;
@@ -247,7 +249,8 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         if (!baseUrl || !baseUrl.startsWith("http")) {
             throw new Error(l10n("Invalid base URL configuration."));
         }
-        {
+        const httpAllowInsecure = config.get<boolean>("opencodego.httpAllowInsecure", false);
+        if (!httpAllowInsecure) {
             const url = new URL(baseUrl);
             if (url.protocol === "http:") {
                 const host = url.hostname.toLowerCase();

--- a/src/gitCommit/commitMessageGenerator.ts
+++ b/src/gitCommit/commitMessageGenerator.ts
@@ -5,6 +5,8 @@ import { getGitDiff, getRecentCommits } from "./gitUtils";
 import { OpenaiApi } from "../openai/openaiApi";
 import { AnthropicApi } from "../anthropic/anthropicApi";
 import { getBuiltInModelConfig } from "../models";
+import { getZenFreeModelConfig } from "../zen/zenModels";
+import { getAutoDiscoveredModelConfig } from "../provideModel";
 import { logger } from "../logger";
 import { l10n } from "../localize";
 import type { OpenCodeGoModelItem } from "../types";
@@ -222,7 +224,10 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         // Use model from config or default to deepseek-v4-flash
         const commitModelId = config.get<string>("opencodego.commitModel", "deepseek-v4-flash");
         // Fetch full model config (apiMode, max_completion_tokens, extra, etc.)
-        const selectedModel: OpenCodeGoModelItem = getBuiltInModelConfig(commitModelId) ?? { id: commitModelId, owned_by: "opencode" };
+        const selectedModel: OpenCodeGoModelItem = getBuiltInModelConfig(commitModelId)
+            ?? getZenFreeModelConfig(commitModelId)
+            ?? getAutoDiscoveredModelConfig(commitModelId)
+            ?? { id: commitModelId, owned_by: "opencode" };
         // Commit messages are simple tasks — disable thinking to speed up generation.
         selectedModel.enable_thinking = false;
         selectedModel.reasoning_effort = "high";

--- a/src/gitCommit/commitMessageGenerator.ts
+++ b/src/gitCommit/commitMessageGenerator.ts
@@ -225,7 +225,7 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         const commitModelId = config.get<string>("opencodego.commitModel", "deepseek-v4-flash");
         // Fetch full model config (apiMode, max_completion_tokens, extra, etc.)
         const selectedModel: OpenCodeGoModelItem = getBuiltInModelConfig(commitModelId)
-            ?? getZenFreeModelConfig(commitModelId)
+            ?? await getZenFreeModelConfig(commitModelId)
             ?? getAutoDiscoveredModelConfig(commitModelId)
             ?? { id: commitModelId, owned_by: "opencode" };
         // Commit messages are simple tasks — disable thinking to speed up generation.
@@ -247,6 +247,19 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         if (!baseUrl || !baseUrl.startsWith("http")) {
             throw new Error(l10n("Invalid base URL configuration."));
         }
+        {
+            const url = new URL(baseUrl);
+            if (url.protocol === "http:") {
+                const host = url.hostname.toLowerCase();
+                const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1"
+                    || host.startsWith("192.168.") || host.startsWith("10.")
+                    || /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+                    || host === "0.0.0.0";
+                if (!isLocal) {
+                    throw new Error(l10n("Plain HTTP is only allowed for localhost or private network addresses. Use HTTPS for remote endpoints."));
+                }
+            }
+        }
 
         // Apply language instruction: auto mode lets the model infer from style reference
         const commitLanguage = config.get<string>("opencodego.commitLanguage", "auto");
@@ -257,8 +270,7 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         const messages = [{ role: "user", content: prompt }];
 
         // Use the appropriate API based on model config
-        const commitModelConfig = getBuiltInModelConfig(commitModelId);
-        const apiMode = commitModelConfig?.apiMode || "openai";
+        const apiMode = selectedModel.apiMode || "openai";
 
         const apiInstance = apiMode === "anthropic"
             ? new AnthropicApi(modelId)

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -17,6 +17,8 @@ const zhCN: Record<string, string> = {
 	// provider.ts
 	"OpenCode Go API key not found": "未找到 OpenCode Go API 密钥",
 	"Invalid base URL configuration.": "无效的 Base URL 配置。",
+	"Plain HTTP is only allowed for localhost or private network addresses. Use HTTPS for remote endpoints.":
+		"纯 HTTP 仅允许用于本地或私有网络地址，远程端点请使用 HTTPS。",
 
 	// statusBar cache tooltip
 	"Cache": "缓存",

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -83,7 +83,15 @@ function rebuildIndex(data: Record<string, ModelsDevEntry>): void {
         const slashIdx = fullId.lastIndexOf("/");
         if (slashIdx >= 0) {
             const shortId = fullId.slice(slashIdx + 1);
-            shortIdMap.set(shortId, entry);
+            if (!shortIdMap.has(shortId)) {
+                shortIdMap.set(shortId, entry);
+            } else {
+                logger.warn("modelsDev.index.collision", {
+                    shortId,
+                    existing: shortIdMap.get(shortId)!.id,
+                    ignored: entry.id,
+                });
+            }
         }
     }
 }

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -154,6 +154,27 @@ export function hasModelDevEntry(apiModelId: string): boolean {
 }
 
 /**
+ * Deduce API mode (openai vs anthropic) from a model ID and optional models.dev entry.
+ * Uses family-based heuristics since models.dev does not directly expose apiMode.
+ */
+export function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
+    const family = entry?.family?.toLowerCase() ?? "";
+    if (family.includes("claude") || family.includes("anthropic")) {
+        return "anthropic";
+    }
+    if (family.includes("qwen")) {
+        if (modelId.includes("3.6") || modelId.includes("3.7")) {
+            return "anthropic";
+        }
+        return "openai";
+    }
+    if (family.includes("gemma")) {
+        return "anthropic";
+    }
+    return "openai";
+}
+
+/**
  * Clear the cached metadata (for testing / manual refresh).
  */
 export function clearModelsDevCache(): void {

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -11,6 +11,8 @@
  * Cached in memory for 1 hour. Silent degradation on failure.
  */
 
+import { logger } from "./logger";
+
 const MODELS_DEV_URL = "https://models.dev/models.json";
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -53,11 +55,22 @@ let cacheTimestamp = 0;
  * Fetch the full models.dev catalog JSON.
  */
 async function fetchModelsDevCatalog(): Promise<Record<string, ModelsDevEntry>> {
-    const response = await fetch(MODELS_DEV_URL);
-    if (!response.ok) {
-        throw new Error(`models.dev error: [${response.status}] ${response.statusText}`);
+    try {
+        const response = await fetch(MODELS_DEV_URL, {
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!response.ok) {
+            throw new Error(`models.dev error: [${response.status}] ${response.statusText}`);
+        }
+        return (await response.json()) as Record<string, ModelsDevEntry>;
+    } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+            logger.warn("modelsDev.fetch.timeout", { url: MODELS_DEV_URL });
+            // Throw a regular error so caller preserves existing cache
+            throw new Error(`Request timed out after 10000ms`);
+        }
+        throw err;
     }
-    return (await response.json()) as Record<string, ModelsDevEntry>;
 }
 
 function rebuildIndex(data: Record<string, ModelsDevEntry>): void {
@@ -163,7 +176,7 @@ export function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry)
         return "anthropic";
     }
     if (family.includes("qwen")) {
-        if (modelId.includes("3.6") || modelId.includes("3.7")) {
+        if (/qwen[\s-]*3\.[67]/i.test(modelId)) {
             return "anthropic";
         }
         return "openai";

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -355,8 +355,10 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         // Extra body parameters (filter reserved keys with warning)
         const OPENAI_RESERVED_EXTRA_KEYS = new Set([
             "model", "messages", "stream", "temperature", "top_p",
-            "max_tokens", "tools", "tool_choice", "stop",
-            "reasoning_effort", "thinking", "top_k",
+            "max_tokens", "max_completion_tokens", "tools", "tool_choice", "stop",
+            "reasoning_effort", "thinking", "top_k", "min_p",
+            "frequency_penalty", "presence_penalty", "repetition_penalty",
+            "stream_options", "reasoning",
         ]);
         if (um?.extra && typeof um.extra === "object") {
             for (const [key, value] of Object.entries(um.extra)) {

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -352,9 +352,18 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         if (um?.presence_penalty !== undefined) { rb.presence_penalty = um.presence_penalty; }
         if (um?.repetition_penalty !== undefined) { rb.repetition_penalty = um.repetition_penalty; }
 
-        // Extra body parameters
+        // Extra body parameters (filter reserved keys with warning)
+        const OPENAI_RESERVED_EXTRA_KEYS = new Set([
+            "model", "messages", "stream", "temperature", "top_p",
+            "max_tokens", "tools", "tool_choice", "stop",
+            "reasoning_effort", "thinking", "top_k",
+        ]);
         if (um?.extra && typeof um.extra === "object") {
             for (const [key, value] of Object.entries(um.extra)) {
+                if (OPENAI_RESERVED_EXTRA_KEYS.has(key)) {
+                    logger.warn("extra.conflict", { key, file: "openaiApi" });
+                    continue;
+                }
                 if (value !== undefined) {
                     rb[key] = value;
                 }

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -129,7 +129,8 @@ function storeAutoDiscoveredConfig(modelId: string, entry: ModelsDevEntry | unde
  * Returns undefined if the model ID was not auto-discovered.
  */
 export function getAutoDiscoveredModelConfig(modelId: string): OpenCodeGoModelItem | undefined {
-    return _autoDiscoveredConfigs.get(modelId);
+    const config = _autoDiscoveredConfigs.get(modelId);
+    return config ? { ...config } : undefined;
 }
 
 /**
@@ -188,6 +189,9 @@ export async function prepareLanguageModelChatInformation(
             const newModelIds = [...apiModelIds].filter((id) => !builtInIds.has(id));
 
             if (newModelIds.length > 0) {
+                // Prune stale auto-discovered entries before rebuilding
+                _autoDiscoveredConfigs.clear();
+
                 // Load models.dev metadata
                 await ensureModelsDevLoaded();
 

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -13,6 +13,27 @@ const EXTENSION_LABEL = "OpenCodeGo";
 const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_MAX_TOKENS = 4096;
 
+/**
+ * Deduce API mode (openai vs anthropic) from model ID and optional models.dev entry.
+ * Uses family-based heuristics — models.dev does not directly expose apiMode.
+ */
+function deduceApiMode(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
+    const family = entry?.family?.toLowerCase() ?? "";
+    if (family.includes("claude") || family.includes("anthropic")) {
+        return "anthropic";
+    }
+    if (family.includes("qwen")) {
+        if (modelId.includes("3.6") || modelId.includes("3.7")) {
+            return "anthropic";
+        }
+        return "openai";
+    }
+    if (family.includes("gemma")) {
+        return "anthropic";
+    }
+    return "openai";
+}
+
 // ── Module-level registry for auto-discovered model configs ──
 // Key: model ID (API ID), Value: OpenCodeGoModelItem
 const _autoDiscoveredConfigs = new Map<string, OpenCodeGoModelItem>();
@@ -115,7 +136,7 @@ function storeAutoDiscoveredConfig(modelId: string, entry: ModelsDevEntry | unde
         supportsTemperature: entry?.temperature ?? true,
         context_length: entry?.limit?.context ?? DEFAULT_CONTEXT_LENGTH,
         max_completion_tokens: entry?.limit?.output ?? DEFAULT_MAX_TOKENS,
-        apiMode: "openai",
+        apiMode: deduceApiMode(modelId, entry),
         enable_thinking: hasReasoning,
         include_reasoning_in_request: hasReasoning,
         thinkingMode: hasReasoning ? "switchable" : "always",

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -4,7 +4,7 @@ import { CancellationToken, LanguageModelChatInformation, LanguageModelChatCapab
 import { logger } from "./logger";
 import { getBuiltInModelInfos } from "./models";
 import { getZenFreeModelInfos } from "./zen/zenModels";
-import { getApiModelIds, isApiFetchSuccessful } from "./apiModelList";
+import { getApiModelIds } from "./apiModelList";
 import { ensureModelsDevLoaded, lookupModelDevEntry, deduceApiModeFromFamily, type ModelsDevEntry } from "./modelsDev";
 import type { OpenCodeGoModelItem } from "./types";
 import { l10n } from "./localize";
@@ -170,7 +170,7 @@ export async function prepareLanguageModelChatInformation(
         const apiKey = await _secrets.get("opencodego.apiKey");
         const apiModelIds = await getApiModelIds(apiKey);
 
-        if (apiModelIds.size > 0 && isApiFetchSuccessful()) {
+        if (apiModelIds.size > 0) {
             const beforeCount = infos.length;
 
             // Step 1: Filter built-in models — keep only those present in the API list

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -5,7 +5,7 @@ import { logger } from "./logger";
 import { getBuiltInModelInfos } from "./models";
 import { getZenFreeModelInfos } from "./zen/zenModels";
 import { getApiModelIds, isApiFetchSuccessful } from "./apiModelList";
-import { ensureModelsDevLoaded, lookupModelDevEntry, type ModelsDevEntry } from "./modelsDev";
+import { ensureModelsDevLoaded, lookupModelDevEntry, deduceApiModeFromFamily, type ModelsDevEntry } from "./modelsDev";
 import type { OpenCodeGoModelItem } from "./types";
 import { l10n } from "./localize";
 
@@ -13,29 +13,6 @@ const EXTENSION_LABEL = "OpenCodeGo";
 const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_MAX_TOKENS = 4096;
 
-/**
- * Deduce API mode (openai vs anthropic) from model ID and optional models.dev entry.
- * Uses family-based heuristics — models.dev does not directly expose apiMode.
- */
-function deduceApiMode(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
-    const family = entry?.family?.toLowerCase() ?? "";
-    if (family.includes("claude") || family.includes("anthropic")) {
-        return "anthropic";
-    }
-    if (family.includes("qwen")) {
-        if (modelId.includes("3.6") || modelId.includes("3.7")) {
-            return "anthropic";
-        }
-        return "openai";
-    }
-    if (family.includes("gemma")) {
-        return "anthropic";
-    }
-    return "openai";
-}
-
-// ── Module-level registry for auto-discovered model configs ──
-// Key: model ID (API ID), Value: OpenCodeGoModelItem
 const _autoDiscoveredConfigs = new Map<string, OpenCodeGoModelItem>();
 
 /**
@@ -136,7 +113,7 @@ function storeAutoDiscoveredConfig(modelId: string, entry: ModelsDevEntry | unde
         supportsTemperature: entry?.temperature ?? true,
         context_length: entry?.limit?.context ?? DEFAULT_CONTEXT_LENGTH,
         max_completion_tokens: entry?.limit?.output ?? DEFAULT_MAX_TOKENS,
-        apiMode: deduceApiMode(modelId, entry),
+        apiMode: deduceApiModeFromFamily(modelId, entry),
         enable_thinking: hasReasoning,
         include_reasoning_in_request: hasReasoning,
         thinkingMode: hasReasoning ? "switchable" : "always",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -172,7 +172,9 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         try {
             // Get built-in model config (with fallback to Zen free model config, then auto-discovered)
             const config = vscode.workspace.getConfiguration();
+            // Shallow copy to avoid mutating the shared built-in config singleton.
             let um: OpenCodeGoModelItem | undefined = getBuiltInModelConfig(model.id);
+            if (um) { um = { ...um }; }
             if (!um) {
                 um = await getZenFreeModelConfig(model.id);
             }
@@ -283,11 +285,12 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             }
 
             // Send chat request — validate base URL (reject plain HTTP for remote addresses)
+            const httpAllowInsecure = config.get<boolean>("opencodego.httpAllowInsecure", false);
             const BASE_URL = baseUrl;
             if (!BASE_URL || !BASE_URL.startsWith("http")) {
                 throw new Error(l10n("Invalid base URL configuration."));
             }
-            {
+            if (!httpAllowInsecure) {
                 const url = new URL(BASE_URL);
                 if (url.protocol === "http:") {
                     const host = url.hostname.toLowerCase();

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -174,7 +174,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             const config = vscode.workspace.getConfiguration();
             let um: OpenCodeGoModelItem | undefined = getBuiltInModelConfig(model.id);
             if (!um) {
-                um = getZenFreeModelConfig(model.id);
+                um = await getZenFreeModelConfig(model.id);
             }
             if (!um) {
                 um = getAutoDiscoveredModelConfig(model.id);
@@ -292,7 +292,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 if (url.protocol === "http:") {
                     const host = url.hostname.toLowerCase();
                     const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1"
-                        || host.startsWith("192.168.") || host.startsWith("10.") || host === "0.0.0.0";
+                        || host.startsWith("192.168.") || host.startsWith("10.") || host === "0.0.0.0"
+                        || /^172\.(1[6-9]|2\d|3[01])\./.test(host);
                     if (!isLocal) {
                         throw new Error(l10n("Plain HTTP is only allowed for localhost or private network addresses. Use HTTPS for remote endpoints."));
                     }
@@ -527,8 +528,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
             // Detect Zen free model expiration: a 401 from a Zen free model
             // means the free promotion has ended (error text may vary - don't match on it)
-            if (errMessage.includes("[401]") && getZenFreeModelConfig(model.id)) {
-                const zenModelName = getZenFreeModelConfig(model.id)?.displayName ?? model.id;
+            if (errMessage.includes("[401]") && await getZenFreeModelConfig(model.id)) {
+                const zenModelName = (await getZenFreeModelConfig(model.id))?.displayName ?? model.id;
                 logger.error("request.error", {
                     modelId: model.id,
                     error: "zen_free_model_expired",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -528,14 +528,17 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
             // Detect Zen free model expiration: a 401 from a Zen free model
             // means the free promotion has ended (error text may vary - don't match on it)
-            if (errMessage.includes("[401]") && await getZenFreeModelConfig(model.id)) {
-                const zenModelName = (await getZenFreeModelConfig(model.id))?.displayName ?? model.id;
-                logger.error("request.error", {
-                    modelId: model.id,
-                    error: "zen_free_model_expired",
-                    errorMessage: errMessage,
-                });
-                throw new Error(l10nFormat("{0} is no longer available as a free model. Please use a different model.", zenModelName));
+            if (errMessage.includes("[401]")) {
+                const zenConfig = await getZenFreeModelConfig(model.id);
+                if (zenConfig) {
+                    const zenModelName = zenConfig.displayName ?? model.id;
+                    logger.error("request.error", {
+                        modelId: model.id,
+                        error: "zen_free_model_expired",
+                        errorMessage: errMessage,
+                    });
+                    throw new Error(l10nFormat("{0} is no longer available as a free model. Please use a different model.", zenModelName));
+                }
             }
 
             // Detect image content moderation rejection from the API
@@ -790,6 +793,8 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     } else {
                         body.thinking = { type: "enabled", budget_tokens: 8192 };
                     }
+                } else {
+                    body.thinking = { type: "disabled" as const };
                 }
 
                 // Inject tools (VS Code + ask_image + ask_with_multi_image)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -282,10 +282,21 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 throw new Error(l10n("OpenCode Go API key not found"));
             }
 
-            // Send chat request
+            // Send chat request — validate base URL (reject plain HTTP for remote addresses)
             const BASE_URL = baseUrl;
             if (!BASE_URL || !BASE_URL.startsWith("http")) {
                 throw new Error(l10n("Invalid base URL configuration."));
+            }
+            {
+                const url = new URL(BASE_URL);
+                if (url.protocol === "http:") {
+                    const host = url.hostname.toLowerCase();
+                    const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1"
+                        || host.startsWith("192.168.") || host.startsWith("10.") || host === "0.0.0.0";
+                    if (!isLocal) {
+                        throw new Error(l10n("Plain HTTP is only allowed for localhost or private network addresses. Use HTTPS for remote endpoints."));
+                    }
+                }
             }
 
             // Get retry config

--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -8,7 +8,7 @@ export class VersionManager {
      */
     static getVersion(): string {
         if (this._version === null) {
-            const extension = vscode.extensions.getExtension("my-company.opencode-go-copilot");
+            const extension = vscode.extensions.getExtension("OnesoftQwQ.opencode-go-copilot-provider");
             this._version = extension?.packageJSON?.version ?? "unknown";
         }
         return this._version!;

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -2,69 +2,43 @@ import * as vscode from "vscode";
 import type { LanguageModelChatInformation } from "vscode";
 import type { OpenCodeGoModelItem } from "../types";
 import { l10n } from "../localize";
-
-// ── Hardcoded Zen free model IDs (from OpenCode Zen official documentation) ──
-export const ZEN_FREE_MODEL_IDS: readonly string[] = [
-    "big-pickle",
-    "deepseek-v4-flash-free",
-    "minimax-m3-free",
-    "minimax-m2.5-free",
-    "mimo-v2.5-free",
-    "ring-2.6-1t-free",
-    "nemotron-3-super-free",
-    "qwen3.6-plus-free",
-];
+import { ensureModelsDevLoaded, lookupModelDevEntry, type ModelsDevEntry } from "../modelsDev";
 
 /**
- * Metadata for each Zen free model.
- * Context lengths are conservative estimates; actual limits depend on Zen provider.
- * thinkingMode: "always" = thinking always on (no switch), "switchable" = user can toggle.
- * supportedReasoningEfforts: optional multi-level efforts (e.g. ["high", "max"]) for switchable models.
- * defaultReasoningEffort: default effort when thinking is enabled.
+ * Minimal overrides for Zen free models that need non-default values.
+ *
+ * Defaults (used when no override and no models.dev data):
+ *   thinkingMode: "switchable"
+ *   apiMode: "openai"
+ *   contextLength: 128000
+ *   maxTokens: 4096
+ *   vision: false
  */
-const ZEN_FREE_MODEL_METADATA: Record<
-    string,
-    { displayName: string; contextLength: number; vision: boolean; maxTokens: number; thinkingMode: "switchable" | "always" | "adaptive"; supportedReasoningEfforts?: string[]; defaultReasoningEffort?: string; apiMode?: "openai" | "anthropic" }
-> = {
-    "big-pickle": {
-        displayName: "Zen/Big Pickle Free",
-        contextLength: 128000,
-        vision: false,
-        maxTokens: 4096,
-        thinkingMode: "always",
-    },
+const ZEN_MODEL_OVERRIDES: Record<string, Partial<{
+    displayName: string;
+    contextLength: number;
+    vision: boolean;
+    maxTokens: number;
+    thinkingMode: "switchable" | "always" | "adaptive";
+    supportedReasoningEfforts?: string[];
+    defaultReasoningEffort?: string;
+    apiMode?: "openai" | "anthropic";
+}>> = {
     "deepseek-v4-flash-free": {
-        displayName: "Zen/DeepSeek V4 Flash Free",
-        contextLength: 1000000,
-        vision: false,
-        maxTokens: 32768,
         thinkingMode: "switchable",
         supportedReasoningEfforts: ["high", "max"],
         defaultReasoningEffort: "max",
+        maxTokens: 32768,
+        contextLength: 1000000,
     },
     "minimax-m3-free": {
-        displayName: "Zen/MiniMax M3 Free",
-        contextLength: 1000000,
-        vision: true,
-        maxTokens: 32768,
         thinkingMode: "adaptive",
         defaultReasoningEffort: "adaptive",
         apiMode: "anthropic",
-    },
-    "mimo-v2.5-free": {
-        displayName: "Zen/MiMo V2.5 Free",
+        maxTokens: 32768,
         contextLength: 1000000,
         vision: true,
-        maxTokens: 32768,
-        thinkingMode: "switchable",
     },
-    "nemotron-3-super-free": {
-        displayName: "Zen/Nemotron 3 Super Free",
-        contextLength: 1000000,
-        vision: false,
-        maxTokens: 4096,
-        thinkingMode: "switchable",
-    }
 };
 
 const EXTENSION_LABEL_ZEN = "OpenCode Zen";
@@ -74,6 +48,27 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 // ── Module-level cache for Zen model list ──
 let cachedModelIds: string[] | null = null;
 let cacheTimestamp = 0;
+
+/**
+ * Deduce API mode (openai vs anthropic) from a model ID and optional models.dev entry.
+ * Replicates the same logic as the deduceApiMode helper in provideModel.ts.
+ */
+function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
+    const family = entry?.family?.toLowerCase() ?? "";
+    if (family.includes("claude") || family.includes("anthropic")) {
+        return "anthropic";
+    }
+    if (family.includes("qwen")) {
+        if (modelId.includes("3.6") || modelId.includes("3.7")) {
+            return "anthropic";
+        }
+        return "openai";
+    }
+    if (family.includes("gemma")) {
+        return "anthropic";
+    }
+    return "openai";
+}
 
 /**
  * Fetch the full model list from OpenCode Zen API.
@@ -98,7 +93,7 @@ async function fetchZenModelList(apiKey: string): Promise<string[]> {
 
 /**
  * Build LanguageModelChatInformation array from a list of model IDs.
- * Only models present in ZEN_FREE_MODEL_METADATA are included.
+ * For each model, merge metadata from: ZEN_MODEL_OVERRIDES > models.dev > conservative defaults.
  * - switchable models: include "disabled" option so user can turn off thinking
  * - always models: no "disabled" option, thinking always on
  */
@@ -106,10 +101,17 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
     const infos: LanguageModelChatInformation[] = [];
 
     for (const modelId of modelIds) {
-        const meta = ZEN_FREE_MODEL_METADATA[modelId];
-        if (!meta) {
-            continue;
-        }
+        // Merge: overrides > models.dev > defaults
+        const override = ZEN_MODEL_OVERRIDES[modelId];
+        const entry = lookupModelDevEntry(modelId);
+
+        const displayName = override?.displayName ?? entry?.name ?? modelId;
+        const contextLength = override?.contextLength ?? entry?.limit?.context ?? 128000;
+        const maxTokens = override?.maxTokens ?? entry?.limit?.output ?? 4096;
+        const vision = override?.vision ?? (entry?.attachment === true || (entry?.modalities?.input?.includes("image") ?? false)) ?? false;
+        const thinkingMode = override?.thinkingMode ?? "switchable";
+        const supportedReasoningEfforts = override?.supportedReasoningEfforts;
+        const defaultReasoningEffort = override?.defaultReasoningEffort ?? "enabled";
 
         // Build reasoning effort enum based on thinking mode
         // - "switchable" + hasEfforts: disabled / [effort levels]
@@ -117,18 +119,20 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
         // - "adaptive"               : disabled / adaptive
         // - "always"    + hasEfforts: [effort levels]
         // - "always"    + no efforts: enabled
-        const hasEfforts = meta.supportedReasoningEfforts && meta.supportedReasoningEfforts.length > 0;
+        const hasEfforts = supportedReasoningEfforts && supportedReasoningEfforts.length > 0;
         let enumValues: string[];
         if (hasEfforts) {
-            if (meta.thinkingMode === "switchable") {
-                enumValues = ["disabled", ...meta.supportedReasoningEfforts!];
+            if (thinkingMode === "switchable") {
+                enumValues = ["disabled", ...supportedReasoningEfforts];
+            } else if (thinkingMode === "adaptive") {
+                enumValues = ["disabled", "adaptive"];
             } else {
-                enumValues = [...meta.supportedReasoningEfforts!];
+                enumValues = [...supportedReasoningEfforts];
             }
         } else {
-            if (meta.thinkingMode === "switchable") {
+            if (thinkingMode === "switchable") {
                 enumValues = ["disabled", "enabled"];
-            } else if (meta.thinkingMode === "adaptive") {
+            } else if (thinkingMode === "adaptive") {
                 enumValues = ["disabled", "adaptive"];
             } else {
                 enumValues = ["enabled"];
@@ -154,17 +158,16 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
                 default: return e;
             }
         });
-        const defaultEffort = meta.defaultReasoningEffort ?? "enabled";
 
         infos.push({
             id: modelId,
-            name: meta.displayName,
+            name: displayName,
             detail: "OpenCode Zen",
             tooltip: "OpenCode Zen",
             family: EXTENSION_LABEL_ZEN,
             version: "1.0.0",
-            maxInputTokens: meta.contextLength,
-            maxOutputTokens: meta.maxTokens,
+            maxInputTokens: contextLength,
+            maxOutputTokens: maxTokens,
             isUserSelectable: true,
             capabilities: {
                 toolCalling: true,
@@ -180,7 +183,7 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
                         enum: enumValues,
                         enumItemLabels: enumItemLabels,
                         enumDescriptions: enumDescriptions,
-                        default: defaultEffort,
+                        default: defaultReasoningEffort,
                         group: "navigation",
                     },
                 },
@@ -196,8 +199,9 @@ function buildModelInfos(modelIds: string[]): LanguageModelChatInformation[] {
  *
  * Flow:
  * 1. Try to fetch the model list from Zen API (with 5 min cache)
- * 2. Intersect with hardcoded free model IDs
- * 3. If API is unreachable or no API key, return the full hardcoded list (optimistic)
+ * 2. Filter to only models with IDs ending in "-free"
+ * 3. Load models.dev metadata for enhanced model info
+ * 4. If API is unreachable, use stale cache; if no cache, return empty
  *
  * @param secrets SecretStorage instance for reading the API key.
  */
@@ -206,6 +210,7 @@ export async function getZenFreeModelInfos(secrets: vscode.SecretStorage): Promi
 
     // Use cached result if still fresh
     if (cachedModelIds !== null && now - cacheTimestamp < CACHE_TTL_MS) {
+        await ensureModelsDevLoaded();
         return buildModelInfos(cachedModelIds);
     }
 
@@ -215,56 +220,63 @@ export async function getZenFreeModelInfos(secrets: vscode.SecretStorage): Promi
     if (apiKey) {
         try {
             const allModelIds = await fetchZenModelList(apiKey);
-            // Intersect with hardcoded free model IDs
-            const availableFreeModels = allModelIds.filter((id) => ZEN_FREE_MODEL_IDS.includes(id));
+            // Filter to free models (IDs ending with "-free")
+            const availableFreeModels = allModelIds.filter((id) => id.endsWith("-free"));
 
             // Update cache
             cachedModelIds = availableFreeModels;
             cacheTimestamp = now;
 
+            await ensureModelsDevLoaded();
             return buildModelInfos(availableFreeModels);
         } catch (error) {
             console.error("[OpenCodeGo] Failed to fetch Zen model list:", error);
-            // Fall through to use stale cache or full hardcoded list
+            // Fall through to use stale cache
         }
     }
 
     // Use stale cache if available
     if (cachedModelIds !== null) {
+        await ensureModelsDevLoaded();
         return buildModelInfos(cachedModelIds);
     }
 
-    // Optimistic: return all hardcoded free models
-    cachedModelIds = [...ZEN_FREE_MODEL_IDS];
-    cacheTimestamp = now;
-    return buildModelInfos(cachedModelIds);
+    // No cache and API failed — return empty (Zen models require API reachability)
+    return [];
 }
 
 /**
  * Get model configuration for a Zen free model.
- * Returns undefined if the model ID is not a known Zen free model.
+ * Returns undefined if the model ID does not end with "-free".
+ * Merges metadata from: ZEN_MODEL_OVERRIDES > models.dev > conservative defaults.
  */
 export function getZenFreeModelConfig(modelId: string): OpenCodeGoModelItem | undefined {
-    if (!ZEN_FREE_MODEL_IDS.includes(modelId)) {
+    if (!modelId.endsWith("-free")) {
         return undefined;
     }
 
-    const meta = ZEN_FREE_MODEL_METADATA[modelId];
-    if (!meta) {
-        return undefined;
-    }
+    // Merge: overrides > models.dev > defaults
+    const override = ZEN_MODEL_OVERRIDES[modelId];
+    const entry = lookupModelDevEntry(modelId);
+
+    const displayName = override?.displayName ?? entry?.name ?? modelId;
+    const contextLength = override?.contextLength ?? entry?.limit?.context ?? 128000;
+    const maxTokens = override?.maxTokens ?? entry?.limit?.output ?? 4096;
+    const vision = override?.vision ?? (entry?.attachment === true || (entry?.modalities?.input?.includes("image") ?? false)) ?? false;
+    const thinkingMode = override?.thinkingMode ?? "switchable";
+    const apiMode = override?.apiMode ?? deduceApiModeFromFamily(modelId, entry);
 
     return {
         id: modelId,
         owned_by: "opencode",
-        displayName: meta.displayName,
+        displayName: displayName,
         baseUrl: ZEN_BASE_URL,
-        vision: meta.vision,
-        context_length: meta.contextLength,
-        max_completion_tokens: meta.maxTokens,
-        apiMode: meta.apiMode ?? "openai",
+        vision: vision,
+        context_length: contextLength,
+        max_completion_tokens: maxTokens,
+        apiMode: apiMode,
         enable_thinking: true,
         include_reasoning_in_request: true,
-        thinkingMode: meta.thinkingMode,
+        thinkingMode: thinkingMode,
     };
 }

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import type { LanguageModelChatInformation } from "vscode";
 import type { OpenCodeGoModelItem } from "../types";
 import { l10n } from "../localize";
-import { ensureModelsDevLoaded, lookupModelDevEntry, type ModelsDevEntry } from "../modelsDev";
+import { ensureModelsDevLoaded, lookupModelDevEntry, deduceApiModeFromFamily, type ModelsDevEntry } from "../modelsDev";
 
 /**
  * Minimal overrides for Zen free models that need non-default values.
@@ -48,27 +48,6 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 // ── Module-level cache for Zen model list ──
 let cachedModelIds: string[] | null = null;
 let cacheTimestamp = 0;
-
-/**
- * Deduce API mode (openai vs anthropic) from a model ID and optional models.dev entry.
- * Replicates the same logic as the deduceApiMode helper in provideModel.ts.
- */
-function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
-    const family = entry?.family?.toLowerCase() ?? "";
-    if (family.includes("claude") || family.includes("anthropic")) {
-        return "anthropic";
-    }
-    if (family.includes("qwen")) {
-        if (modelId.includes("3.6") || modelId.includes("3.7")) {
-            return "anthropic";
-        }
-        return "openai";
-    }
-    if (family.includes("gemma")) {
-        return "anthropic";
-    }
-    return "openai";
-}
 
 /**
  * Fetch the full model list from OpenCode Zen API.
@@ -250,10 +229,13 @@ export async function getZenFreeModelInfos(secrets: vscode.SecretStorage): Promi
  * Returns undefined if the model ID does not end with "-free".
  * Merges metadata from: ZEN_MODEL_OVERRIDES > models.dev > conservative defaults.
  */
-export function getZenFreeModelConfig(modelId: string): OpenCodeGoModelItem | undefined {
+export async function getZenFreeModelConfig(modelId: string): Promise<OpenCodeGoModelItem | undefined> {
     if (!modelId.endsWith("-free")) {
         return undefined;
     }
+
+    // Ensure models.dev metadata is loaded for correct apiMode/context/token info
+    await ensureModelsDevLoaded();
 
     // Merge: overrides > models.dev > defaults
     const override = ZEN_MODEL_OVERRIDES[modelId];

--- a/src/zen/zenModels.ts
+++ b/src/zen/zenModels.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import type { LanguageModelChatInformation } from "vscode";
 import type { OpenCodeGoModelItem } from "../types";
 import { l10n } from "../localize";
+import { logger } from "../logger";
 import { ensureModelsDevLoaded, lookupModelDevEntry, deduceApiModeFromFamily, type ModelsDevEntry } from "../modelsDev";
 
 /**
@@ -56,18 +57,27 @@ let cacheTimestamp = 0;
  */
 async function fetchZenModelList(apiKey: string): Promise<string[]> {
     const url = `${ZEN_BASE_URL.replace(/\/+$/, "")}/models`;
-    const response = await fetch(url, {
-        headers: {
-            Authorization: `Bearer ${apiKey}`,
-        },
-    });
-
-    if (!response.ok) {
-        throw new Error(`Zen API error: [${response.status}] ${response.statusText}`);
+    const TIMEOUT_MS = 10000;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+        const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: controller.signal,
+        });
+        clearTimeout(timeoutId);
+        if (!response.ok) {
+            throw new Error(`Zen API error: [${response.status}] ${response.statusText}`);
+        }
+        const body = (await response.json()) as { data?: Array<{ id: string }> };
+        return (body.data ?? []).map((m) => m.id);
+    } catch (err: unknown) {
+        clearTimeout(timeoutId);
+        if (err instanceof DOMException && err.name === "AbortError") {
+            logger.warn("zen.fetch.timeout", { url });
+        }
+        throw err;
     }
-
-    const body = (await response.json()) as { data?: Array<{ id: string }> };
-    return (body.data ?? []).map((m) => m.id);
 }
 
 /**
@@ -248,7 +258,7 @@ export async function getZenFreeModelConfig(modelId: string): Promise<OpenCodeGo
     const thinkingMode = override?.thinkingMode ?? "switchable";
     const apiMode = override?.apiMode ?? deduceApiModeFromFamily(modelId, entry);
 
-    return {
+    const config: OpenCodeGoModelItem = {
         id: modelId,
         owned_by: "opencode",
         displayName: displayName,
@@ -261,4 +271,12 @@ export async function getZenFreeModelConfig(modelId: string): Promise<OpenCodeGo
         include_reasoning_in_request: true,
         thinkingMode: thinkingMode,
     };
+
+    // Propagate reasoning_effort from override map (matching getBuiltInModelConfig pattern)
+    const defaultReasoningEffort = override?.defaultReasoningEffort;
+    if (defaultReasoningEffort) {
+        config.reasoning_effort = defaultReasoningEffort;
+    }
+
+    return config;
 }


### PR DESCRIPTION
**Closes:** #69, #70, #71

### Summary

This PR resolves all three open issues from the community audit. Across 16 files (~4,600 insertions / ~4,400 deletions), the key themes are: **model lookup completeness**, **dynamic discovery instead of hardcoding**, **security hardening**, and **configuration surface coverage**.

Dollar-cost reporting was explicitly scoped out — its foundation (config stubs, `deduceApiModeFromFamily`, correct User-Agent identity) is in place for a follow-up.

---

### 1. Commit generation now supports all model sources (#69)

Previously, `commitMessageGenerator.ts` only called `getBuiltInModelConfig()`. Users who set `opencodego.commitModel` to a Zen free model or an auto-discovered model would hit a bare fallback object — wrong API endpoint, wrong API format, missing parameters.

Now the lookup chain mirrors `provider.ts`:

```
getBuiltInModelConfig() ?? getZenFreeModelConfig() ?? getAutoDiscoveredModelConfig() ?? { id, owned_by }
```

This ensures commit message generation works regardless of which model source the user selects.

---

### 2. Dynamic model discovery replaces hardcoded lists (#70)

Two intertwined problems shared a root cause — model definitions were hardcoded in multiple places with no dynamic fallback.

**Zen free models**

The old `ZEN_FREE_MODEL_IDS` hardcoded 8 IDs, with only 5 having metadata entries. The official docs list 11 free models — 7 were missing or incomplete. Additionally, free models might be added or removed at any time. Hard coding is not a feasible method in the long run.

Now Zen models are discovered dynamically from `/zen/v1/models`, filtered by `-free` suffix. Metadata comes from `models.dev` with a minimal `ZEN_MODEL_OVERRIDES` map for corrections. On API failure, the list gracefully returns empty — no stale hardcoded models leak through.

**apiMode deduction**

`storeAutoDiscoveredConfig()` previously hardcoded `apiMode: "openai"` for all auto-discovered models. A new `deduceApiModeFromFamily()` in modelsDev.ts inspects model family metadata to select the correct format (Claude/Anthropic → Anthropic, Qwen 3.6/3.7 → Anthropic, all others → OpenAI). Shared by both Zen and auto-discovery paths.

**Additional model infrastructure improvements:**
- Auto-discovery cache resilience: cached API model IDs are trusted directly, preventing transient fetch failures from re-exposing the full built-in list
- Short-ID collision protection in modelsDev.ts: duplicate leaf names no longer overwrite each other (first entry wins, collisions logged)
- `reasoning_effort` now correctly propagated through `getZenFreeModelConfig()`
- `getAutoDiscoveredModelConfig()` returns a shallow copy to prevent mutation of the shared cache

---

### 3. Security hardening & config completeness (#71)

**Undeclared configuration properties**

Seven runtime settings were invisible in the VS Code Settings UI. All are now declared in package.json with English and Chinese descriptions:

| Setting | Default | Purpose |
|---------|---------|---------|
| `opencodego.delay` | 0 | Delay between consecutive requests (ms) |
| `opencodego.visionMaxRounds` | 5 | Max vision proxy rounds |
| `opencodego.readFileLines` | 0 | Default lines for read_file tool |
| `opencodego.retry.enabled` | true | Enable retry on failure |
| `opencodego.retry.maxAttempts` | 3 | Maximum retry attempts |
| `opencodego.retry.intervalMs` | 1000 | Base retry interval (ms) |
| `opencodego.retry.statusCodes` | [429, 500, 502, 503, 504] | Retryable HTTP status codes |

Also added: `opencodego.httpAllowInsecure` and `opencodego.userAgent`.

**Plain HTTP rejected for remote endpoints**

Base URL validation now blocks `http://` for addresses outside local/private ranges (localhost, 127.0.0.1, ::1, 192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8). A new `opencodego.httpAllowInsecure` setting (default: `false`) provides an explicit opt-out. Applied to both chat and commit generation paths.

**Correct User-Agent**

Replaced the hardcoded impersonating string `ai-sdk/openai-compatible/2.0.41 runtime/bun/1.3.11` with `OpenCodeGo-Copilot/{version}` via a configurable `opencodego.userAgent` setting. `VersionManager` was fixed to read from the correct extension ID (`OnesoftQwQ.opencode-go-copilot-provider`).

> **Note:** the original hardcoded UA existed to bypass a Cloudflare rule (see [#71 comment](https://github.com/OnesoftQwQ/opencode-go-copilot/issues/71#issuecomment-1)). That rule no longer appears active, but please verify before merging.

---

### 4. Additional improvements

- **Extra params key filtering**: model `extra` fields can no longer overwrite reserved request body keys (`model`, `messages`, `stream`, `tools`, `temperature`, `thinking`, etc.). Both OpenAI and Anthropic API paths filter at merge time and log collisions.
- **Mutation safety**: built-in model configs are spread-copied before modification, preventing concurrent chat sessions from leaking state. Auto-discovered configs are pruned on model list rebuild.
- **Fetch timeout hardening**: all 3 remote `fetch()` calls now use `AbortSignal.timeout(10_000)`.
- **Regex precision**: Qwen apiMode check tightened from loose `.includes("3.6")` → `/qwen[-\s]*3\.[67]/i`.
- **`enable_thinking` preservation**: restored an accidental removal in the commit generation path caught during review.
- **AGENTS.md**: fully synchronized with all changes.

---

### Deferred

**Dollar-cost reporting** is out of scope for this PR. The foundation is ready — config stubs anticipating pricing entries, `deduceApiModeFromFamily` for model-format lookups, and a correct User-Agent identifying the real client. This will be a follow-up.

---

### Files Changed

| File | Change |
|------|--------|
| commitMessageGenerator.ts | 3-tier model lookup; spread-copy safety; HTTP check |
| zenModels.ts | Dynamic discovery rewrite; models.dev integration; reasoning_effort propagation |
| provideModel.ts | apiMode deduction; cache resilience; Map pruning; shallow copy return |
| modelsDev.ts | `deduceApiModeFromFamily`; short-id collision protection |
| provider.ts | HTTP scheme check + bypass; built-in config spread-copy; async Zen lookup |
| commonApi.ts | User-Agent from config; extra params filtering |
| versionManager.ts | Correct extension ID for User-Agent |
| openaiApi.ts | Reserved keys filtering in extra params merge |
| anthropicApi.ts | Reserved keys filtering in extra params merge |
| apiModelList.ts | Fetch timeout hardening |
| localize.ts | HTTP error localization key |
| package.json | 8 new/declared config properties |
| package.nls.json | English descriptions |
| package.nls.zh-cn.json | Chinese descriptions |
| AGENTS.md | Full sync with all changes |