### PR TITLE
Fix DeepSeek V4 API protocol routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1417,5 +1417,5 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 ### 6.11 模型协议判定维护说明
 
 - `models.dev` 中的 `provider.npm` 仅表示目录使用的 SDK 适配器，不一定代表公开 API 的请求协议。
-- 模型族特征（例如 Claude、Qwen 3.6/3.7、Gemma）优先决定 Anthropic/OpenAI 模式；SDK hint 仅作为无法从模型族判断时的回退。
+- 模型族特征（例如 Claude、Qwen 3.6/3.7、Gemma、DeepSeek）优先决定 Anthropic/OpenAI 模式；SDK hint 仅作为目录没有模型族信息时的回退。
 - DeepSeek V4 等模型必须继续通过 OpenAI-compatible endpoint 发送，避免误发到 Anthropic `/messages` endpoint 导致 400 错误。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1413,3 +1413,9 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 - `commit.start/end/error` — 提交消息生成
 - `openai.stream.*` / `anthropic.stream.*` — 流式处理
 - `apiKey.missing` — API Key 缺失
+
+### 6.11 模型协议判定维护说明
+
+- `models.dev` 中的 `provider.npm` 仅表示目录使用的 SDK 适配器，不一定代表公开 API 的请求协议。
+- 模型族特征（例如 Claude、Qwen 3.6/3.7、Gemma）优先决定 Anthropic/OpenAI 模式；SDK hint 仅作为无法从模型族判断时的回退。
+- DeepSeek V4 等模型必须继续通过 OpenAI-compatible endpoint 发送，避免误发到 Anthropic `/messages` endpoint 导致 400 错误。

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -496,11 +496,11 @@ export function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry)
     }
     if (family.includes("gemma")) return "anthropic";
 
-    // Only use the SDK hint when the model family does not identify the
-    // public wire protocol. This prevents DeepSeek and other non-Anthropic
-    // families from being routed to `/messages` by an implementation detail
-    // in the catalog.
-    if (entry?.provider?.npm?.includes("anthropic")) return "anthropic";
+    // Only use the SDK hint when the catalog has no family information at
+    // all. A non-Anthropic family (for example `deepseek-flash`) already
+    // identifies this as an OpenAI-compatible model; letting the SDK hint
+    // override it would route the request to `/messages` incorrectly.
+    if (!family && entry?.provider?.npm?.includes("anthropic")) return "anthropic";
     return "openai";
 }
 

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -483,12 +483,11 @@ export function hasModelDevEntry(apiModelId: string): boolean {
  * Deduce API mode (openai vs anthropic) from a model ID and optional catalog entry.
  * Uses family-based heuristics since the catalog does not directly expose apiMode.
  *
- * Also checks the `provider.npm` field: @ai-sdk/anthropic → anthropic.
+ * The `provider.npm` field is only a fallback hint. Some gateway catalog
+ * entries use an Anthropic SDK adapter internally even though the public
+ * endpoint for the model is OpenAI-compatible (for example DeepSeek V4).
  */
 export function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
-    // Check provider npm hint first
-    if (entry?.provider?.npm?.includes("anthropic")) return "anthropic";
-
     const family = entry?.family?.toLowerCase() ?? "";
     if (family.includes("claude") || family.includes("anthropic")) return "anthropic";
     if (family.includes("qwen")) {
@@ -496,6 +495,12 @@ export function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry)
         return "openai";
     }
     if (family.includes("gemma")) return "anthropic";
+
+    // Only use the SDK hint when the model family does not identify the
+    // public wire protocol. This prevents DeepSeek and other non-Anthropic
+    // families from being routed to `/messages` by an implementation detail
+    // in the catalog.
+    if (entry?.provider?.npm?.includes("anthropic")) return "anthropic";
     return "openai";
 }
 


### PR DESCRIPTION
## Summary

- Fix API protocol detection for DeepSeek V4 models.
- Treat `provider.npm` as a fallback hint instead of the primary protocol source.
- Document the catalog/protocol distinction in `AGENTS.md`.

## Root cause

The models.dev catalog reports `@ai-sdk/anthropic` for DeepSeek V4 even though the OpenCode Go public endpoint expects the OpenAI-compatible request format. The previous precedence routed the request to Anthropic `/messages`, producing HTTP 400 errors.

## Validation

- `npm run compile`
- `npm run lint` (existing unused-variable warnings only)
- `git diff --check`
