### PR TITLE
feat: add enableCommitGeneration setting to hide SCM button

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 				{
 					"command": "opencodego.generateGitCommitMessage",
 					"group": "navigation",
-					"when": "config.git.enabled && scmProvider == git && !opencodego.isGeneratingCommit"
+					"when": "config.opencodego.enableCommitGeneration && config.git.enabled && scmProvider == git && !opencodego.isGeneratingCommit"
 				},
 				{
 					"command": "opencodego.abortGitCommitMessage",
@@ -140,7 +140,7 @@
 			"commandPalette": [
 				{
 					"command": "opencodego.generateGitCommitMessage",
-					"when": "config.git.enabled && !opencodego.isGeneratingCommit"
+					"when": "config.opencodego.enableCommitGeneration && config.git.enabled && !opencodego.isGeneratingCommit"
 				},
 				{
 					"command": "opencodego.abortGitCommitMessage",
@@ -400,6 +400,11 @@
 					"minimum": 1,
 					"maximum": 60,
 					"markdownDescription": "%config.usageRefreshInterval.desc%"
+				},
+				"opencodego.enableCommitGeneration": {
+					"type": "boolean",
+					"default": true,
+					"description": "%config.enableCommitGeneration.desc%"
 				}
 			}
 		}

--- a/package.nls.json
+++ b/package.nls.json
@@ -57,6 +57,7 @@
 	"config.retry.maxAttempts.desc": "Maximum number of retry attempts for failed API requests. Default: 3.",
 	"config.retry.intervalMs.desc": "Initial delay in milliseconds before the first retry attempt. Increases exponentially with each retry. Default: 1000.",
 	"config.retry.statusCodes.desc": "Additional HTTP status codes that trigger automatic retry beyond the default set (429, 500, 502, 503, 504). Default: [].",
+	"config.enableCommitGeneration.desc": "Show the generate commit message button in the SCM panel. When disabled, the magic wand button and the command palette entry are hidden.",
 	"command.setModelPreset": "Set Model Temperature Preset",
 	"walkthrough.title": "OpenCode Go for Copilot Chat",
 	"walkthrough.description": "Set up OpenCode Go models in Copilot Chat.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -57,6 +57,7 @@
 	"config.retry.maxAttempts.desc": "失败 API 请求的最大重试次数。默认值: 3。",
 	"config.retry.intervalMs.desc": "首次重试前的初始延迟时间（毫秒）。每次重试后按指数递增。默认值: 1000。",
 	"config.retry.statusCodes.desc": "除默认状态码（429、500、502、503、504）之外，额外触发自动重试的 HTTP 状态码列表。默认值: []。",
+	"config.enableCommitGeneration.desc": "在源代码管理面板显示生成提交消息按钮。关闭后，魔法棒按钮和命令面板入口将被隐藏。",
 	"command.setModelPreset": "设置模型温度预设",
 	"walkthrough.title": "OpenCode Go for Copilot Chat",
 	"walkthrough.description": "在 Copilot Chat 中配置 OpenCode Go 模型。",


### PR DESCRIPTION
### Changes

**1. New `opencodego.enableCommitGeneration` setting to hide the commit generation button**
- Added `opencodego.enableCommitGeneration` (boolean, default `true`) to control the visibility of the commit message generation UI.
- SCM title bar button (magic wand) now respects the setting via its `when` clause - hidden when disabled.
- Command palette entry for `opencodego.generateGitCommitMessage` also respects the setting.
- When disabled, both the SCM button and the command entry are completely hidden; the underlying generate/abort commands remain registered and fully functional.

### Files Changed

| File | Change |
| ---- | ------ |
| `package.json` | New config property + `when` conditions on SCM menu and command palette entries |
| `package.nls.json` | English description for the new setting |
| `package.nls.zh-cn.json` | Chinese description for the new setting |

### Notes

- Default `true`: existing users see no behavior change; only those who opt out get the UI hidden.
- Rebased onto latest `master` (v1.9.2). This replaces the `enableCommitGeneration` change from PR #61, which also contained unrelated Auth Cookie work now split out.