### PR TITLE
feat: enhance status bar cache hit rate display with progress bars, cost tracking and single-flush usage accounting

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -22,6 +22,12 @@ const zhCN: Record<string, string> = {
 	// statusBar cache tooltip
 	"Cache": "缓存",
 	"({0} cached, {1}%)": "(已缓存 {0}, 命中率 {1}%)",
+	"Hit rate (last call)": "命中率(上一次调用)",
+	"Total hit rate": "总命中",
+	"Input": "输入",
+	"Output": "输出",
+	"Total saved": "累计节省",
+	"Cost": "费用",
 
 	// statusBar Go usage tooltip section
 	"Week": "周",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -323,15 +323,22 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             if (apiMode === "anthropic") {
                 // Anthropic API mode
                 const anthropicApi = new AnthropicApi(model.id);
+                // Accumulate incremental usage during streaming; flushed once
+                // after the stream ends so counters/tooltip update only when
+                // the current response has finished (no mid-stream flicker or
+                // double-counting if the API reports usage more than once).
+                let anthropicUsage: StreamUsage | undefined;
                 anthropicApi.onUsage = (usage) => {
                     usageReportedDuringStream = true;
                     // Always report to native Copilot indicator (use original progress, not trackingProgress wrapper)
                     reportNativeUsage(usage, progress);
-                    // Conditionally update Advanced Token indicator
                     if (enableThirdPartyIndicator) {
-                        recordUsage(usage);
-                        updateCumulativeTooltip(this.statusBarItem);
-                        updateStatusBarWithApiPrompt(this.statusBarItem);
+                        if (!anthropicUsage) {
+                            anthropicUsage = { ...usage };
+                        } else {
+                            anthropicUsage.promptTokens += usage.promptTokens;
+                            anthropicUsage.completionTokens += usage.completionTokens;
+                        }
                     }
                 };
                 const anthropicMessages = await anthropicApi.convertMessages(messages, modelConfig);
@@ -396,18 +403,25 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     token: token,
                     options: options,
                 });
+
+                // Response finished: flush accumulated usage once
+                if (enableThirdPartyIndicator && anthropicUsage) {
+                    recordUsage(anthropicUsage, um?.cost);
+                    updateStatusBarWithApiPrompt(this.statusBarItem);
+                }
             } else {
                 // OpenAI Chat Completions API mode
                 const openaiApi = new OpenaiApi(model.id);
+                // OpenAI usage chunks are cumulative; keep the last (final)
+                // report and flush once after the stream ends so counters and
+                // the tooltip only update when the response has finished.
+                let openaiUsage: StreamUsage | undefined;
                 openaiApi.onUsage = (usage) => {
                     usageReportedDuringStream = true;
                     // Always report to native Copilot indicator (use original progress, not trackingProgress wrapper)
                     reportNativeUsage(usage, progress);
-                    // Conditionally update Advanced Token indicator
                     if (enableThirdPartyIndicator) {
-                        recordUsage(usage);
-                        updateCumulativeTooltip(this.statusBarItem);
-                        updateStatusBarWithApiPrompt(this.statusBarItem);
+                        openaiUsage = usage;
                     }
                 };
                 const openaiMessages = await openaiApi.convertMessages(messages, modelConfig);
@@ -472,6 +486,12 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     token: token,
                     options: options,
                 });
+
+                // Response finished: flush final usage once
+                if (enableThirdPartyIndicator && openaiUsage) {
+                    recordUsage(openaiUsage, um?.cost);
+                    updateStatusBarWithApiPrompt(this.statusBarItem);
+                }
             }
 
             // Fallback: if API did not return usage data, use client-side calculation for native indicator
@@ -484,7 +504,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 };
                 reportNativeUsage(fallbackUsage, progress);
                 if (enableThirdPartyIndicator) {
-                    recordUsage(fallbackUsage);
+                    recordUsage(fallbackUsage, um?.cost);
                     updateCumulativeTooltip(this.statusBarItem);
                 }
             }

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -17,6 +17,12 @@ let cumulativeInputTokens = 0;
 let cumulativeOutputTokens = 0;
 let cumulativeCacheHitTokens = 0;
 let cumulativeCacheMissTokens = 0;
+// Cumulative cost in USD (reset together with the token counters above)
+let cumulativeCost = 0;
+let cumulativeSaved = 0;
+// Most recent API call's cache hit rate (updated on every usage report)
+let lastUsageHitRate: number | undefined;
+let prevUsageHitRate: number | undefined;
 
 // Go usage polling state (usage shown in the status bar tooltip)
 let usageSecrets: vscode.SecretStorage | undefined;
@@ -132,15 +138,23 @@ export function formatTokenCount(value: number): string {
 }
 
 /**
- * Update the status bar main text with the Go plan usage (5h window),
- * e.g. "$(symbol-numeric) Go 5H 65%", or "$(symbol-numeric) Go --"
- * while no usage data is available.
+ * Update the status bar main text with the Go plan usage (5h window) and
+ * the overall cache hit rate, e.g. "$(symbol-numeric) 5H:65%,Hit:99%", or
+ * "$(symbol-numeric) Go --" while no usage data is available.
  */
 function updateStatusBarGoUsageText(statusBarItem: vscode.StatusBarItem): void {
     const usage = getUsageSnapshot();
     const percent = usage?.rolling?.percent;
-    statusBarItem.text = percent !== undefined
-        ? `$(symbol-numeric) Go 5H ${Math.round(percent)}%`
+    const totalCache = cumulativeCacheHitTokens + cumulativeCacheMissTokens;
+    const parts: string[] = [];
+    if (percent !== undefined) {
+        parts.push(`5H:${Math.round(percent)}%`);
+    }
+    if (totalCache > 0) {
+        parts.push(`Hit:${Math.round((cumulativeCacheHitTokens / totalCache) * 100)}%`);
+    }
+    statusBarItem.text = parts.length > 0
+        ? `$(symbol-numeric) ${parts.join(",")}`
         : "$(symbol-numeric) Go --";
 }
 
@@ -203,12 +217,26 @@ function resetCumulativeCounters(): void {
     cumulativeOutputTokens = 0;
     cumulativeCacheHitTokens = 0;
     cumulativeCacheMissTokens = 0;
+    cumulativeCost = 0;
+    cumulativeSaved = 0;
+}
+
+/**
+ * Model cost information (USD per 1M tokens).
+ */
+export interface ModelCost {
+    cache_read: number;
+    input: number;
+    output: number;
 }
 
 /**
  * Record streaming usage data into cumulative counters.
+ * Cost accounting follows the same formula as opencode's session tracker:
+ * tokens × price / 1e6, summed over input, output and cache-read tokens.
+ * Savings = cache-hit tokens × (input price − cache-read price).
  */
-export function recordUsage(usage: StreamUsage): void {
+export function recordUsage(usage: StreamUsage, cost?: ModelCost): void {
     cumulativeInputTokens += usage.promptTokens;
     cumulativeOutputTokens += usage.completionTokens;
     if (usage.cacheHitTokens !== undefined) {
@@ -217,10 +245,28 @@ export function recordUsage(usage: StreamUsage): void {
     if (usage.cacheMissTokens !== undefined) {
         cumulativeCacheMissTokens += usage.cacheMissTokens;
     }
+    // Track the most recent API call's cache hit rate (for the tooltip)
+    if (usage.cacheHitTokens !== undefined && usage.cacheMissTokens !== undefined) {
+        const callTotal = usage.cacheHitTokens + usage.cacheMissTokens;
+        if (callTotal > 0) {
+            prevUsageHitRate = lastUsageHitRate;
+            lastUsageHitRate = (usage.cacheHitTokens / callTotal) * 100;
+        }
+    }
+    if (cost) {
+        const cacheHit = usage.cacheHitTokens ?? 0;
+        const cacheMiss = usage.cacheMissTokens ?? 0;
+        cumulativeCost +=
+            (usage.promptTokens * cost.input) / 1_000_000 +
+            (usage.completionTokens * cost.output) / 1_000_000 +
+            (cacheHit * cost.cache_read) / 1_000_000 +
+            (cacheMiss * cost.input) / 1_000_000;
+        cumulativeSaved += (cacheHit * (cost.input - cost.cache_read)) / 1_000_000;
+    }
 }
 
 /**
- * Append the OpenCode Go plan usage section to the tooltip lines.
+ * Append the OpenCode Go plan usage section to the tooltip rows.
  * Compact layout: one line per window ("5H 65%" / "周 30%" / "月 12%")
  * and the 5h window reset countdown.
  * Shows nothing when disabled or no data is cached.
@@ -244,45 +290,107 @@ function appendGoUsageTooltipLines(lines: string[]): void {
     }
 
     for (const [label, window] of present) {
-        lines.push(`${label}——${Math.round(window.percent)}%`);
+        lines.push(`<div>${label}——${Math.round(window.percent)}%</div>`);
     }
     if (usage.rolling?.resetsAt) {
         const reset = formatResetDuration(usage.rolling.resetsAt);
         if (reset) {
-            lines.push(l10nFormat("5h window resets in {0}", reset));
+            lines.push(`<div>${l10nFormat("5h window resets in {0}", reset)}</div>`);
         }
     }
 }
 
 /**
- * Update the status bar tooltip with cumulative input/output token counts,
- * DeepSeek cache info (if available) and OpenCode Go plan usage (if enabled
- * and data is cached).
+ * Render a continuous pill progress bar as HTML (theme-aware).
+ * A filled green segment followed by a muted empty segment, both rendered as
+ * solid color blocks via span background-color (the only visual styles
+ * allowed by VS Code's markdown sanitizer). The segments are filled with
+ * invisible &nbsp; so the result is one continuous bar — no glyphs, no gaps.
+ */
+function renderProgressBar(percent: number): string {
+    const clamped = Math.max(0, Math.min(100, percent));
+    const totalUnits = 20; // 20 invisible units → 5% per unit
+    const filled = Math.round((clamped / 100) * totalUnits);
+    const empty = totalUnits - filled;
+    const nbsp = "\u00A0";
+    let html = "";
+    if (filled > 0) {
+        // NOTE: the sanitizer regex requires every style declaration to end
+        // with a semicolon, otherwise the whole style attr is stripped.
+        html += `<span style="background-color:var(--vscode-charts-green);">${nbsp.repeat(filled)}</span>`;
+    }
+    if (empty > 0) {
+        html += `<span style="background-color:var(--vscode-descriptionForeground);">${nbsp.repeat(empty)}</span>`;
+    }
+    return html;
+}
+
+/**
+ * Format a USD amount, trimming trailing zeros (e.g. 0.102, 0.0097).
+ */
+function formatUsd(value: number): string {
+    return Number(value.toFixed(4)).toString();
+}
+
+/**
+ * Update the status bar tooltip with cache hit rates, token details,
+ * cost/savings (if model cost data is available) and OpenCode Go plan
+ * usage (if enabled and data is cached).
+ *
+ * The tooltip is a MarkdownString with supportHtml enabled, so the progress
+ * bars and cost rows render as rich HTML (theme-colored, like a modern UI)
+ * instead of plain text. All HTML stays within VS Code's sanitizer
+ * allow-list (div/span/strong + span style color with --vscode-* vars).
  */
 export function updateCumulativeTooltip(statusBarItem: vscode.StatusBarItem): void {
-    const arrowUp = "\u2191";
-    const arrowDown = "\u2193";
-    const lines: string[] = [];
+    const rows: string[] = [];
 
-    // Line 1: cumulative input + cache info
-    let inputLine = `${arrowUp} ${formatTokenCount(cumulativeInputTokens)}`;
-    if (cumulativeCacheHitTokens > 0 || cumulativeCacheMissTokens > 0) {
-        const totalCache = cumulativeCacheHitTokens + cumulativeCacheMissTokens;
-        const cachePercent = totalCache > 0
-            ? Math.round((cumulativeCacheHitTokens / totalCache) * 100)
-            : 0;
-        const cacheFormatted = formatTokenCount(cumulativeCacheHitTokens);
-        inputLine += ` ${l10nFormat("({0} cached, {1}%)", cacheFormatted, cachePercent)}`;
+    // Most recent API call hit rate, with delta vs the previous call
+    if (lastUsageHitRate !== undefined) {
+        rows.push(`<div><strong>${l10n("Hit rate (last call)")}</strong></div>`);
+        let deltaHtml = "";
+        if (prevUsageHitRate !== undefined) {
+            const delta = lastUsageHitRate - prevUsageHitRate;
+            const arrow = delta >= 0 ? "\u2191" : "\u2193";
+            const deltaColor = delta >= 0 ? "var(--vscode-charts-green)" : "var(--vscode-charts-red)";
+            deltaHtml = ` <span style="color:${deltaColor}">${arrow}${Math.abs(delta).toFixed(1)}%</span>`;
+        }
+        rows.push(`<div>${renderProgressBar(lastUsageHitRate)} ${lastUsageHitRate.toFixed(1)}%${deltaHtml}</div>`);
     }
-    lines.push(inputLine);
 
-    // Line 2: cumulative output
-    lines.push(`${arrowDown} ${formatTokenCount(cumulativeOutputTokens)}`);
+    // Total hit rate (session cumulative)
+    const totalCache = cumulativeCacheHitTokens + cumulativeCacheMissTokens;
+    if (totalCache > 0) {
+        const totalPercent = (cumulativeCacheHitTokens / totalCache) * 100;
+        rows.push(
+            `<div><strong>${l10n("Total hit rate")}:</strong></div>`,
+            `<div>${renderProgressBar(totalPercent)} ${totalPercent.toFixed(1)}%</div>`
+        );
+    }
+
+    // Token details (session cumulative): total input = cache hit + miss
+    if (cumulativeCacheHitTokens > 0 || cumulativeCacheMissTokens > 0) {
+        rows.push(
+            `<div>${l10n("Input")}: ${formatTokenCount(cumulativeCacheHitTokens + cumulativeCacheMissTokens)} tok &nbsp;&nbsp;&nbsp;&nbsp;(${formatTokenCount(cumulativeCacheHitTokens)}+${formatTokenCount(cumulativeCacheMissTokens)})</div>`
+        );
+    }
+    rows.push(`<div>${l10n("Output")}: ${cumulativeOutputTokens.toLocaleString()} tok</div>`);
+
+    // Cost & savings (only shown when model cost data was provided)
+    if (cumulativeCost > 0 || cumulativeSaved > 0) {
+        rows.push(
+            `<div>${l10n("Total saved")}: <span style="color:var(--vscode-charts-green)">~$${formatUsd(cumulativeSaved)}</span></div>`,
+            `<div>${l10n("Cost")}: <span style="color:var(--vscode-charts-yellow)">$${formatUsd(cumulativeCost)}</span></div>`
+        );
+    }
 
     // Section 3: OpenCode Go plan usage (optional)
-    appendGoUsageTooltipLines(lines);
+    appendGoUsageTooltipLines(rows);
 
-    statusBarItem.tooltip = lines.join("\n");
+    const md = new vscode.MarkdownString("", true);
+    md.supportHtml = true;
+    md.appendMarkdown(rows.join(""));
+    statusBarItem.tooltip = md;
 }
 
 /**


### PR DESCRIPTION
## What

Enhances the status bar (right-bottom) with a modern, information-rich cache-hit tooltip, plus a more compact main text.

### Tooltip (hover) now shows
- **Last call hit rate** — updated once per API request *after* the response finishes, with a delta vs the previous call (green up / red down)
- **Total hit rate** (session cumulative) with a **graphical progress bar** (continuous colored bar built from sanitizer-safe `span background-color` — no text glyphs)
- **Input tokens** (`66.8K+34.6K` = cache hit + miss) and **output tokens**
- **Cumulative cost & savings** (USD, from models.dev catalog pricing) when available

### Status bar main text
- Compact: `$(symbol-numeric) 5H:0%,Hit:99%` (was `Go 5H 0%`) — shows the overall cache hit rate alongside the Go plan 5h window usage.

### Correct usage accounting
- Usage is now flushed **once after the streaming response finishes** instead of being recorded on every mid-stream `onUsage` callback. This prevents double-counting when the API reports usage multiple times during streaming (some OpenAI-compatible endpoints include `usage` on every chunk).
  - OpenAI mode: keeps the final cumulative usage report
  - Anthropic mode: aggregates incremental `message_delta` usage
  - Fallback (no usage reported): client-side estimate, unchanged
- Cumulative counters reset when a new conversation starts.

## Files changed

- `src/statusBar.ts` — new hit-rate state, `recordUsage` cost/savings accumulation, sanitizer-safe progress bar renderer, rewritten tooltip builder, status bar text update
- `src/provider.ts` — usage accounting moved from stream-time `onUsage` to post-stream single flush (both Anthropic and OpenAI paths)
- `src/localize.ts` — new zh-CN strings

## Notes

- Cost formula mirrors opencode's session tracker (`tokens x price / 1e6`, cache read at `cache_read` price; savings = hit x (input - cache_read)).
- Progress bars respect the hover sanitizer's strict style allow-list (`color`/`background-color`/`border-radius` only, semicolon-terminated), verified against `vscode/src/vs/base/browser/markdownRenderer.ts`.