### PR TITLE
feat: add OpenAI Responses API support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ models.dev 目录通过 `reasoning_options` 字段提供每个模型的思考能
 │  │   4. 应用请求延迟 (delay)                                     │  │
 │  │   5. 构建请求 → API 路由选择                                  │  │
 │  │      ├─ apiMode="openai"           → OpenaiApi                │  │
-│  │      ├─ apiMode="openai-responses" → ResponsesApi（规划中）   │  │
+│  │      ├─ apiMode="openai-responses" → ResponsesApi            │  │
 │  │      └─ apiMode="anthropic"        → AnthropicApi             │  │
 │  │   6. 发送 HTTP 请求 (fetch with undici + 超时控制)             │  │
 │  │   7. 流式解析响应 → Progress<LanguageModelResponsePart2>      │  │
@@ -426,13 +426,15 @@ src/
 | `commonApi.ts`                        | ~467 | `CommonApi<TMessage,TRequestBody>` 抽象基类（图片存储、工具调用拦截、User-Agent 配置读取）                                                                                                             |
 | `provideModel.ts`                     | ~180 | 模型信息提供函数：以 catalog 的 `opencode-go` provider 全量构建列表（可选按 API 列表过滤），Zen 免费模型从 `opencode` provider 按 `isZenFreeModelId()`（`-free` 后缀 + 硬编码 `big-pickle`）过滤；1 分钟间隔缓存与并发去重                                                                      |
 | `provideToken.ts`                     | ~100 | Token 用量计算                                                                                                                                                                                         |
-| `utils.ts`                            | ~285 | 工具函数 (重试、角色映射、工具转换等)                                                                                                                                                                  |
+| `utils.ts`                            | ~490 | 工具函数（重试、角色映射、OpenAI Chat/Responses 工具格式转换等）                                                                                                                                       |
 | `statusBar.ts`                        | ~317 | 状态栏创建、更新、累计计数器、Go 用量轮询与 tooltip 区块渲染                                                                                                                                           |
 | `logger.ts`                           | ~55  | 日志输出 (LogOutputChannel)                                                                                                                                                                            |
 | `localize.ts`                         | ~109 | 中英文国际化（含 `low/medium/high/xhigh/max` 思考强度标签）                                                                                                                                            |
 | `versionManager.ts`                   | ~35  | 扩展版本信息（使用正确扩展 ID `OnesoftQwQ.opencode-go-copilot-provider`）                                                                                                                              |
 | `openai/openaiApi.ts`                 | ~613 | OpenAI 格式 API 实现 (消息转换/请求构建/流式处理/图片代理)                                                                                                                                             |
 | `openai/openaiTypes.ts`               | ~75  | OpenAI 类型定义                                                                                                                                                                                        |
+| `openai/responsesApi.ts`              | ~410 | OpenAI Responses 格式 API 实现：typed input Items、扁平工具定义、请求参数映射、Responses SSE 文本/推理/工具/usage 解析                                                                                   |
+| `openai/responsesTypes.ts`            | ~125 | OpenAI Responses 请求、输入 Item、工具、usage 与流事件类型定义                                                                                                                                         |
 | `anthropic/anthropicApi.ts`           | ~535 | Anthropic 格式 API 实现 (消息转换/请求构建/流式处理/图片代理)                                                                                                                                          |
 | `anthropic/anthropicTypes.ts`         | ~130 | Anthropic 类型定义                                                                                                                                                                                     |
 | `gitCommit/commitMessageGenerator.ts` | ~295 | Git 提交消息生成逻辑                                                                                                                                                                                   |
@@ -1200,6 +1202,22 @@ API 返回用量数据后重渲染状态栏（主文本 = Go 用量，tooltip = 
 #### `async *createMessage(model, systemPrompt, messages, baseUrl, apiKey, signal?): AsyncGenerator<{ type: "text"; text: string }>`
 
 非流式聊天消息生成器（用于 Git 提交生成）。发送 HTTP 请求后 yield 文本块。注册取消回调：`signal.addEventListener("abort")` 时调用 `reader.cancel()` 立即中断流。
+
+---
+
+### 4.14b `src/openai/responsesApi.ts`
+
+#### `class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequestBody>`
+
+独立的 OpenAI Responses 协议适配器。`convertMessages()` 将 VS Code 文本、图片、工具调用与工具结果转换为 typed input Items；工具结果图片使用 `function_call_output.output` 的 `input_text`/`input_image` 数组。`prepareRequestBody()` 映射 `max_output_tokens`、`reasoning`、`include`、扁平 function tools（`strict:false`）及协议专属 extra 保留键。
+
+#### `processStreamingResponse(responseBody, progress, token): Promise<void>`
+
+解析 Responses SSE 类型事件：文本 delta、推理 delta、function call item/arguments、completed/incomplete/failed/error 与 usage。工具以 `output_index` 复用 `CommonApi` 缓冲和 `LanguageModelToolCallPart` 发射逻辑；terminal failure 直接抛错而不是吞掉。由 `scripts/test-responses-api.mjs` 验证消息/图片/工具转换、请求体、跨 chunk SSE、工具单次发射和 usage 映射。
+
+### 4.14c `src/openai/responsesTypes.ts`
+
+声明 Responses 的输入文本/图片、助手输出、reasoning、`function_call`、`function_call_output`、扁平工具、请求体、usage 与流事件类型。
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 | **自动模型发现**             | 模型列表以 `models.dev` 目录为唯一数据源（1 分钟 TTL 缓存，兼作启动并发激活去重）。通过 `opencodego.enableAutoModelDiscovery` 配置（默认开启）控制是否从 `/zen/go/v1/models` 获取实际可用列表过滤模型选择器（不可用模型隐藏，API 不可用则显示目录全量）。服务商 URL、模型列表、参数（含 `reasoning_options` 思考强度）均从目录自动获取；API 不可用时目录不可用的降级为空列表，待下次拉取恢复                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | **目录容灾回退**             | 目录获取采用三级回退链：官方 `models.dev`（10 秒超时）→ 镜像（`opencodego.modelsDevMirrorUrl`，默认 `https://modelsdev-mirror.onesoft.top/catalog.json`，30 秒超时，请求头携带 `platform: opencode-go-copilot` 及可选 `x-mirror-token`）→ 硬编码兜底目录快照。镜像/兜底命中时按 1 分钟间隔持续重试官方源，官方恢复后自动切回                                                                                                                                                                                                                                                                                                                                                                                                   |
 | **OpenCode Zen 免费模型**    | 通过设置开关启用，从 `models.dev` 目录的 `opencode` 服务商获取模型列表并过滤出免费模型（`-free` 后缀约定 + 硬编码集合 `ZEN_FREE_EXTRA_IDS` 补充无后缀免费模型，如 `big-pickle`），以 `OpenCode Zen` 标识追加到模型选择器。元数据合并链与 Go 模型完全统一：`MODEL_OVERRIDES` > 目录条目 > 保守默认值。支持内存缓存（1 分钟 TTL）                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| **双 API 模式**              | 同时支持 **OpenAI 兼容格式** (`/chat/completions`) 和 **Anthropic 格式** (`/v1/messages`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| **三 API 模式**              | 根据 `models.dev` 的模型级 `provider.npm`（缺失时继承服务商 `npm`）区分 **OpenAI 兼容格式** (`/chat/completions`)、**OpenAI Responses 格式** (`/responses`) 和 **Anthropic 格式** (`/v1/messages`)；旧目录缺少适配器信息时才使用 family 启发式兜底                                                                                                                                                                                                                                                                                                                                             |
 | **流式推理**                 | 支持 SSE (Server-Sent Events) 流式响应，实时输出文本和工具调用                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | **Thinking/推理**            | 支持模型的推理过程展示 ("thinking" 状态)，包括 XML think 块解析                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | **工具调用 (Tool Calling)**  | 支持 VS Code 的 LanguageModelToolCallPart 机制                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
@@ -103,8 +103,9 @@ models.dev 目录通过 `reasoning_options` 字段提供每个模型的思考能
 │  │       (LanguageModelDataPart, MIME type "usage", VS Code 1.116+)│  │
 │  │   4. 应用请求延迟 (delay)                                     │  │
 │  │   5. 构建请求 → API 路由选择                                  │  │
-│  │      ├─ apiMode="openai"    → OpenaiApi                       │  │
-│  │      └─ apiMode="anthropic" → AnthropicApi                    │  │
+│  │      ├─ apiMode="openai"           → OpenaiApi                │  │
+│  │      ├─ apiMode="openai-responses" → ResponsesApi（规划中）   │  │
+│  │      └─ apiMode="anthropic"        → AnthropicApi             │  │
 │  │   6. 发送 HTTP 请求 (fetch with undici + 超时控制)             │  │
 │  │   7. 流式解析响应 → Progress<LanguageModelResponsePart2>      │  │
 │  │      ├─ LanguageModelTextPart     (文本)                      │  │
@@ -168,7 +169,8 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   ├── 2c. 注入 vision 配置
   │       └── modelConfig.vision = um?.vision ?? false
   │
-  ├── 3. 确定 API 模式 (apiMode: "openai" | "anthropic")
+  ├── 3. 确定 API 模式 (apiMode: "openai" | "openai-responses" | "anthropic")
+  │       模型 provider.npm > 服务商 npm > 旧目录 family 兜底
   │
   ├── 4. 记录请求开始日志
   │
@@ -586,7 +588,7 @@ src/
 | `supportsTemperature`          | `boolean` (可选)                  | 是否支持设置 temperature/top_p，默认 true |
 | `useForCommitGeneration`       | `boolean` (可选)                  | 是否用于提交消息生成                      |
 | `delay`                        | `number` (可选)                   | 模型专属请求延迟                          |
-| `apiMode`                      | `string` (可选)                   | API 模式                                  |
+| `apiMode`                      | `ApiMode` (可选)                  | API 模式：OpenAI Chat、Responses 或 Anthropic |
 | `headers`                      | `Record<string, string>` (可选)   | 自定义 HTTP 头                            |
 
 #### `interface ModelsResponse`
@@ -765,9 +767,9 @@ API 实现的抽象基类。
 
 清除缓存的 models.dev 目录数据（重置 `metadataMap`、`shortIdMap`、`providersMap`、`cacheTimestamp` 和 `lastLoadFailed`）。由 `resetAutoDiscoveryState()` 在强制刷新时调用，确保下次查询重新拉取最新目录。
 
-#### `deduceApiModeFromFamily(modelId, entry?)`
+#### `deduceApiModeFromCatalog(modelId, adapterNpm?, entry?)`
 
-根据模型 ID 和可选的 models.dev 条目推断 API 格式（`"openai"` 或 `"anthropic"`）。使用 family 启发式判断：Claude/Anthropic 系列、Qwen 3.6/3.7 系列（匹配 `/qwen[\s-]*3\.[67]/i`）、Gemma 系列 → Anthropic；其余 → OpenAI。被 `catalogModels.resolveFromCatalog()` 调用于确定模型的 apiMode 兜底。
+根据 `models.dev` 适配器包解析 API 格式：`@ai-sdk/openai` → `"openai-responses"`、`@ai-sdk/openai-compatible` → `"openai"`、`@ai-sdk/anthropic` → `"anthropic"`。调用方先选择模型级 `provider.npm`，缺失时继承服务商 `npm`；未识别或旧目录缺失适配器信息时才使用原 family 启发式兜底。由 `scripts/test-api-mode.mjs` 验证三协议映射和旧目录兼容行为。
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,8 +326,9 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
 - **支持无限追问**: 模型拿到图片描述后可以继续调用 ask_image 追问细节（最多 `visionMaxRounds` 次，默认 5）
 - **工具共存**: 每轮同时注入 VS Code 原生工具（read_file 等）+ ask_image，模型可混合使用
 - **图片数据生命周期**: 图片存于 API 实例的 `_localImages` 数组，请求结束后随实例 GC 自动回收；历史记录只持久化调用参数、结果和必要的 reasoning_content，不复制原始图片字节
-- **跨轮工具历史**: `historyCodec.ts` 负责序列化/校验及 OpenAI/Anthropic 标准消息重建，`historyPart.ts` 负责 VS Code DataPart 的创建与解析；旧 history DataPart 在新请求中被消费，不会再次输出造成重复
+- **跨轮工具历史**: `historyCodec.ts` 负责序列化/校验及 OpenAI Chat、OpenAI Responses、Anthropic 三种标准消息重建，`historyPart.ts` 负责 VS Code DataPart 的创建与解析；旧 history DataPart 在新请求中被消费，不会再次输出造成重复
 - **OpenAI 模式**: 使用 `tool_calls` + `tool` role 消息格式构建每轮
+- **OpenAI Responses 模式**: 使用 `function_call` + `function_call_output` input items 构建每轮，并以私有 DataPart 保存 `reasoning.encrypted_content`，支持 `store:false` 的无状态多轮请求
 - **Anthropic 模式**: 使用 `tool_use` + `tool_result` content block 格式构建每轮
 - **参数保留**: 每轮保留 temperature、top_p、thinking 模式等原始参数
 - **DeepSeek 兼容**: 对 DeepSeek 模型的 assistant tool_call 消息注入 reasoning_content 字段
@@ -385,7 +386,10 @@ src/
 ├── versionManager.ts                     # 版本信息管理
 ├── openai/
 │   ├── openaiApi.ts                      # OpenAI 兼容 API 实现
-│   └── openaiTypes.ts                    # OpenAI 类型定义
+│   ├── openaiTypes.ts                    # OpenAI 类型定义
+│   ├── responsesApi.ts                   # OpenAI Responses API 实现
+│   ├── responsesState.ts                 # Responses 加密推理状态 DataPart 编解码
+│   └── responsesTypes.ts                 # OpenAI Responses 类型定义
 ├── anthropic/
 │   ├── anthropicApi.ts                   # Anthropic API 实现
 │   └── anthropicTypes.ts                 # Anthropic 类型定义
@@ -434,6 +438,7 @@ src/
 | `openai/openaiApi.ts`                 | ~613 | OpenAI 格式 API 实现 (消息转换/请求构建/流式处理/图片代理)                                                                                                                                             |
 | `openai/openaiTypes.ts`               | ~75  | OpenAI 类型定义                                                                                                                                                                                        |
 | `openai/responsesApi.ts`              | ~410 | OpenAI Responses 格式 API 实现：typed input Items、扁平工具定义、请求参数映射、Responses SSE 文本/推理/工具/usage 解析                                                                                   |
+| `openai/responsesState.ts`            | ~70  | 校验并编解码 `reasoning.encrypted_content` 私有 DataPart，使 `store:false` 的 Responses 推理模型可在后续请求中无状态续传                                                                               |
 | `openai/responsesTypes.ts`            | ~125 | OpenAI Responses 请求、输入 Item、工具、usage 与流事件类型定义                                                                                                                                         |
 | `anthropic/anthropicApi.ts`           | ~535 | Anthropic 格式 API 实现 (消息转换/请求构建/流式处理/图片代理)                                                                                                                                          |
 | `anthropic/anthropicTypes.ts`         | ~130 | Anthropic 类型定义                                                                                                                                                                                     |
@@ -442,7 +447,7 @@ src/
 | `tokenizer/tokenizerManager.ts`       | ~115 | o200k_base 分词器管理 (含 LRU 缓存)                                                                                                                                                                    |
 | `tokenizer/imageUtils.ts`             | ~130 | 图片尺寸解析 (PNG/GIF/JPEG/WebP)                                                                                                                                                                       |
 | `vision/types.ts`                     | ~53  | Vision proxy 类型定义（`StoredImage`, `InterceptedToolCall`, `ASK_IMAGE_TOOL_DEF`, `ASK_IMAGE_TOOL_NAME`, `ASK_WITH_MULTI_IMAGE_TOOL_DEF`, `ASK_WITH_MULTI_IMAGE_TOOL_NAME`, `DEFAULT_VISION_PROMPT`） |
-| `vision/historyCodec.ts`              | ~150 | 视觉工具历史 DataPart 的 MIME、数据校验/编解码，以及 OpenAI/Anthropic 标准 tool call + tool result 消息重建；由 `scripts/test-vision-history.mjs` 做编解码和双 API 转换器顺序闭环测试（含无推理工具调用回合必须回传空 `reasoning_content` 的 DeepSeek 回归用例） |
+| `vision/historyCodec.ts`              | ~170 | 视觉工具历史 DataPart 的 MIME、数据校验/编解码，以及 OpenAI Chat、OpenAI Responses、Anthropic 标准工具调用/结果重建；由 `scripts/test-vision-history.mjs` 做编解码和三 API 转换器顺序闭环测试（含无推理工具调用回合必须回传空 `reasoning_content` 的 DeepSeek 回归用例） |
 | `vision/historyPart.ts`               | ~28  | 创建和解析 `application/vnd.opencodego.vision-tool-history+json` DataPart；测试脚本使用 VS Code 最小运行时桩验证下一轮消息转换                                                                         |
 | `vision/imageProxy.ts`                | ~95  | 图片代理核心：调用视觉模型描述图片（`callVisionModel`/`callVisionModelMulti`），支持 thinking 模式配置和文本流式转发                                                                                   |
 
@@ -494,17 +499,18 @@ src/
 
 #### `provideLanguageModelChatResponse(model, messages, options, progress, token): Promise<void>`
 
-核心方法：处理聊天请求，流式返回响应。包括模型配置获取（统一 `getCatalogModelConfig`，按 `-free` 后缀 + 硬编码集合自动分流 Zen/Go）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理、API 路由、流式解析、图片代理拦截处理和错误处理。错误处理区分三种情况：用户取消（直接重新抛出原始错误）、超时（友好超时提示）、连接被终止（友好终止提示）。模型配置通过 `{ ...um }` 浅拷贝后再修改 thinking/temperature，防止并发会话间互相泄漏设置。
+核心方法：处理聊天请求，流式返回响应。包括模型配置获取（统一 `getCatalogModelConfig`，按 `-free` 后缀 + 硬编码集合自动分流 Zen/Go）、API Key 验证、推理力度应用、temperature/top_p 注入（模型预设或自定义设置）、延迟控制、超时管理，以及按 `apiMode` 精确路由到 `/chat/completions`、`/responses`、`/v1/messages`。三种协议分别由 `OpenaiApi`、`ResponsesApi`、`AnthropicApi` 转换请求和解析流，之后统一处理图片代理拦截与错误。错误处理区分三种情况：用户取消（直接重新抛出原始错误）、超时（友好超时提示）、连接被终止（友好终止提示）。模型配置通过 `{ ...um }` 浅拷贝后再修改 thinking/temperature，防止并发会话间互相泄漏设置。
 
 #### `private async _handleInterceptedToolCall(params): Promise<void>`
 
-处理图片代理拦截。循环处理最多 `opencodego.visionMaxRounds` 轮（默认 5）。每轮检测 API 实例的 `interceptedToolCall`，发出 thinking 块显示“正在根据图片提问：[问题]”，关闭 thinking 块后视觉模型输出以普通文本流式显示，并立即输出一个 `application/vnd.opencodego.vision-tool-history+json` DataPart 保存调用 ID、参数、视觉结果和 OpenAI 模式所需的 `reasoning_content`。单图调用 `callVisionModel()`，多图调用 `callVisionModelMulti()`，构建本轮 API 请求（追加 assistant tool_call + tool result），注入 VS Code 原生工具 + ask_image（+ ask_with_multi_image 当 >=2 图时）供模型继续使用，保留 temperature/reasoning_effort 等原始参数，DeepSeek 兼容注入 `reasoning_content`。模型不再调用 ask_image/ask_with_multi_image 时退出循环。
+处理图片代理拦截。循环处理最多 `opencodego.visionMaxRounds` 轮（默认 5）。每轮检测 API 实例的 `interceptedToolCall`，发出 thinking 块显示“正在根据图片提问：[问题]”，关闭 thinking 块后视觉模型输出以普通文本流式显示，并立即输出一个 `application/vnd.opencodego.vision-tool-history+json` DataPart 保存调用 ID、参数、视觉结果和 OpenAI Chat 模式所需的 `reasoning_content`。单图调用 `callVisionModel()`，多图调用 `callVisionModelMulti()`，按当前协议追加工具调用与结果，注入 VS Code 原生工具 + ask_image（+ ask_with_multi_image 当 >=2 图时）供模型继续使用，保留 temperature/reasoning_effort 等原始参数；Responses 模式额外续传本轮捕获的 encrypted reasoning item。模型不再调用 ask_image/ask_with_multi_image 时退出循环。
 
 - 视觉模型调用期间用户取消则跳过本轮。
 - 每轮创建独立 AbortController，带独立超时。
 - 每轮注入 VS Code 原生工具 + ask_image + ask_with_multi_image，确保模型可以混合使用。
 - Anthropic 模式额外恢复 `system` 内容（`_systemContent`）和 `thinking` 参数。
 - 第二轮及后续轮次请求体中显式设置 `tool_choice` 为 `"auto"`（OpenAI）或 `{ type: "auto" }`（Anthropic），确保模型可继续调用工具。
+- Responses 模式的第二轮及后续请求继续使用 `store:false`、`/responses` 与扁平工具定义，并在 function call 前放回上一轮 encrypted reasoning item。
 - 使用 `_resetStreamState()` 重置流状态，避免 `_completedToolCallIndices` 等状态在轮次间残留导致工具调用被跳过。
 - `thinking` 字段值统一使用字符串（`"enabled"` / `"disabled"`），与 `prepareRequestBody` 保持一致。
 
@@ -807,7 +813,7 @@ API 实现的抽象基类。
 
 #### `countMessageTokens(text, modelConfig): Promise<number>`
 
-计算消息的总 Token 数。支持 `LanguageModelTextPart`、`LanguageModelDataPart`（图片/二进制）、`LanguageModelToolCallPart`、`LanguageModelToolResultPart`、`LanguageModelThinkingPart`。
+计算消息的总 Token 数。支持 `LanguageModelTextPart`、`LanguageModelDataPart`（图片/二进制）、`LanguageModelToolCallPart`、`LanguageModelToolResultPart`、`LanguageModelThinkingPart`；视觉历史和 Responses encrypted reasoning 两种私有 DataPart 只承担协议回放状态，不按普通二进制重复估算。
 
 #### `textTokenLength(text): Promise<number>`
 
@@ -960,6 +966,10 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 #### `toOpenAIVisionToolMessages(entry): OpenAIChatMessage[]`
 
 重建 OpenAI 标准 `assistant.tool_calls` + `tool` 消息，保留 DeepSeek 需要的 `reasoning_content`。
+
+#### `toResponsesVisionToolItems(entry): ResponsesInputItem[]`
+
+重建 OpenAI Responses 标准 `function_call` + `function_call_output` input items。
 
 #### `toAnthropicVisionToolMessages(entry): AnthropicMessage[]`
 
@@ -1209,13 +1219,21 @@ API 返回用量数据后重渲染状态栏（主文本 = Go 用量，tooltip = 
 
 #### `class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequestBody>`
 
-独立的 OpenAI Responses 协议适配器。`convertMessages()` 将 VS Code 文本、图片、工具调用与工具结果转换为 typed input Items；工具结果图片使用 `function_call_output.output` 的 `input_text`/`input_image` 数组。`prepareRequestBody()` 映射 `max_output_tokens`、`reasoning`、`include`、扁平 function tools（`strict:false`）及协议专属 extra 保留键。
+独立的 OpenAI Responses 协议适配器。`convertMessages()` 将 VS Code 文本、图片、工具调用与工具结果转换为 typed input Items；工具结果图片使用 `function_call_output.output` 的 `input_text`/`input_image` 数组，并还原视觉历史及 encrypted reasoning 私有 DataPart。`prepareRequestBody()` 映射 `max_output_tokens`、`reasoning`、`include`、扁平 function tools（`strict:false`）及协议专属 extra 保留键。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
 
-解析 Responses SSE 类型事件：文本 delta、推理 delta、function call item/arguments、completed/incomplete/failed/error 与 usage。工具以 `output_index` 复用 `CommonApi` 缓冲和 `LanguageModelToolCallPart` 发射逻辑；terminal failure 直接抛错而不是吞掉。由 `scripts/test-responses-api.mjs` 验证消息/图片/工具转换、请求体、跨 chunk SSE、工具单次发射和 usage 映射。
+解析 Responses SSE 类型事件：文本 delta、推理 delta、function call item/arguments、completed/incomplete/failed/error 与 usage。工具以 `output_index` 复用 `CommonApi` 缓冲和 `LanguageModelToolCallPart` 发射逻辑；完整 reasoning item 会被捕获并输出为 `application/vnd.opencodego.responses-reasoning+json` DataPart，供当前图片代理下一轮和未来会话轮次无状态续传；terminal failure 直接抛错而不是吞掉。由 `scripts/test-responses-api.mjs` 验证消息/图片/工具转换、请求体、跨 chunk SSE、工具单次发射、usage 映射与 encrypted reasoning 回放。
 
-### 4.14c `src/openai/responsesTypes.ts`
+#### `takeCapturedReasoningItems(): ResponsesInputItem[]`
+
+取出并清空最近一轮 Responses 流中捕获的 encrypted reasoning items，供 provider 在同一次图片代理循环的下一轮请求中放回。
+
+### 4.14c `src/openai/responsesState.ts`
+
+校验 Responses reasoning output item 的 `id`、`summary` 与 `encrypted_content`，并用专用 VS Code DataPart MIME 编解码，使 `store:false` 请求不依赖服务端保存响应状态。
+
+### 4.14d `src/openai/responsesTypes.ts`
 
 声明 Responses 的输入文本/图片、助手输出、reasoning、`function_call`、`function_call_output`、扁平工具、请求体、usage 与流事件类型。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,7 +528,7 @@ src/
 
 #### `interface ModelMeta`
 
-解析后的模型元数据。models.dev 可提供的字段全部为**必选**（含保守默认值）：`displayName`、`vision`、`reasoning`、`thinkingMode`、`supportedReasoningEfforts`、`defaultReasoningEffort`、`contextLength`、`maxOutputTokens`、`apiMode`、`supportsTemperature`、`toolCalling`、`baseUrl`、`cost`；可选字段：`thinkingBudget`、`status`。
+解析后的模型元数据。models.dev 可提供的字段全部为**必选**（含保守默认值）：`displayName`、`vision`、`reasoning`、`supportsDisablingReasoning`、`thinkingMode`、`supportedReasoningEfforts`、`defaultReasoningEffort`、`contextLength`、`maxOutputTokens`、`apiMode`、`supportsTemperature`、`toolCalling`、`baseUrl`、`cost`；可选字段：`thinkingBudget`、`status`。
 
 #### `isZenFreeModelId(modelId): boolean`
 
@@ -544,7 +544,7 @@ src/
 
 #### `buildCatalogModelInfo(providerId, modelId): LanguageModelChatInformation`
 
-构建模型选择器条目。Zen 模型名前缀 `[Zen]`，deprecated 模型前缀 `[Depr]`。推理强度枚举由 `buildReasoningEnum()` 生成：effort 列表含 `none` 时映射为 `禁用思考` 档；`defaultReasoningEffort` 不在枚举内时回退到最高档（如 adaptive 模型的 `enabled` → `adaptive`）。
+构建模型选择器条目。Zen 模型名前缀 `[Zen]`，deprecated 模型前缀 `[Depr]`。推理强度枚举由 `buildReasoningEnum()` 生成：`disabled` 档在前、`none`/`disabled` effort 值归一为 `禁用思考` 档（已由 `resolveFromCatalog` 过滤，避免重复档）；`defaultReasoningEffort` 不在枚举内时回退到最高档（如 adaptive 模型的 `enabled` → `adaptive`）。当模型为 Responses 原生协议且未声明关闭档位（`supportsDisablingReasoning=false`）时不注入 `disabled` 档，避免用户选择无效的禁用项。
 
 #### `getCatalogModelConfig(modelId): OpenCodeGoModelItem`
 
@@ -597,6 +597,7 @@ src/
 | `useForCommitGeneration`       | `boolean` (可选)                  | 是否用于提交消息生成                      |
 | `delay`                        | `number` (可选)                   | 模型专属请求延迟                          |
 | `apiMode`                      | `ApiMode` (可选)                  | API 模式：OpenAI Chat、Responses 或 Anthropic |
+| `supportsDisablingReasoning`   | `boolean` (可选)                  | 目录是否声明 `none`/`disabled` effort 档；Responses 适配器据此决定能否发送 `reasoning.effort="none"` |
 | `headers`                      | `Record<string, string>` (可选)   | 自定义 HTTP 头                            |
 
 #### `interface ModelsResponse`
@@ -767,9 +768,9 @@ API 实现的抽象基类。
 
 获取服务商提供的全部模型 ID 列表（未加载时返回空数组）。
 
-#### `inferThinkingMode(entry) / inferReasoningEfforts(entry) / inferDefaultReasoningEffort(entry) / inferVision(entry) / inferThinkingBudget(entry)`
+#### `inferThinkingMode(entry) / inferSupportsDisablingReasoning(entry) / inferReasoningEfforts(entry) / inferDefaultReasoningEffort(entry) / inferVision(entry) / inferThinkingBudget(entry)`
 
-从目录条目推断：思考模式（effort values 含 `none`/`disabled` → switchable；仅含实际强度或无选项 → always；非 effort 选项沿用 switchable）、思考强度列表（`effort` 类型 values）、默认强度（最高档）、视觉能力（`attachment`/`modalities`）、思考预算（`budget_tokens` 的 min/max）。因此不会向未声明关闭档位的 Responses 模型强行发送 `reasoning.effort="none"`。
+从目录条目推断：思考模式（`reasoning_options` 非空 → switchable，空但 `reasoning=true` → always；与 Chat/Anthropic 协议关闭思考的方式 `thinking` 标志解耦）、思考强度列表（`effort` 类型 values）、默认强度（最高档）、视觉能力（`attachment`/`modalities`）、思考预算（`budget_tokens` 的 min/max）。`inferSupportsDisablingReasoning()` 判断目录是否声明 `none`/`disabled` effort 档（或 toggle 型开关），**仅**由 Responses 协议适配器用于决定是否发送 `reasoning.effort="none"`：未声明关闭档位的 Responses 模型不发该值，避免端点拒绝；Chat/Anthropic 协议不受影响。
 
 #### `clearModelsDevCache(): void`
 
@@ -1219,7 +1220,7 @@ API 返回用量数据后重渲染状态栏（主文本 = Go 用量，tooltip = 
 
 #### `class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequestBody>`
 
-独立的 OpenAI Responses 协议适配器。`convertMessages()` 将 VS Code 文本、图片、工具调用与工具结果转换为 typed input Items；工具结果图片使用 `function_call_output.output` 的 `input_text`/`input_image` 数组，并还原视觉历史及 encrypted reasoning 私有 DataPart。`prepareRequestBody()` 映射 `max_output_tokens`、`reasoning`、`include`、扁平 function tools（`strict:false`）及协议专属 extra 保留键。
+独立的 OpenAI Responses 协议适配器。`convertMessages()` 将 VS Code 文本、图片、工具调用与工具结果转换为 typed input Items；工具结果图片使用 `function_call_output.output` 的 `input_text`/`input_image` 数组，并还原视觉历史及 encrypted reasoning 私有 DataPart。`prepareRequestBody()` 映射 `max_output_tokens`、`reasoning`、`include`、扁平 function tools（`strict:false`）及协议专属 extra 保留键；仅当模型声明支持（`supportsDisablingReasoning=true`）时才在禁用思考时发送 `reasoning.effort="none"`，否则省略 reasoning 控制并记录日志（模型按自身默认行为思考）。
 
 #### `processStreamingResponse(responseBody, progress, token): Promise<void>`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,7 @@ generateCommitMsg(secrets, scm?)
   │   ├── 用户当前输入 (SCM InputBox)
   │   └── Git Diff 内容
   ├── 调用 API:
-  │   ├── OpenaiApi.createMessage() / AnthropicApi.createMessage()
+  │   ├── 按 models.dev 的 apiMode 选择 OpenaiApi / ResponsesApi / AnthropicApi.createMessage()
   │   └── 流式输出到 SCM InputBox
   └── 清理: 移除 ``` 标记和 <think> 标签
 ```
@@ -528,7 +528,7 @@ src/
 
 #### `interface ModelMeta`
 
-解析后的模型元数据。models.dev 可提供的字段全部为**必选**（含保守默认值）：`displayName`、`vision`、`thinkingMode`、`supportedReasoningEfforts`、`defaultReasoningEffort`、`contextLength`、`maxOutputTokens`、`apiMode`、`supportsTemperature`、`toolCalling`、`baseUrl`、`cost`；可选字段：`thinkingBudget`、`status`。
+解析后的模型元数据。models.dev 可提供的字段全部为**必选**（含保守默认值）：`displayName`、`vision`、`reasoning`、`thinkingMode`、`supportedReasoningEfforts`、`defaultReasoningEffort`、`contextLength`、`maxOutputTokens`、`apiMode`、`supportsTemperature`、`toolCalling`、`baseUrl`、`cost`；可选字段：`thinkingBudget`、`status`。
 
 #### `isZenFreeModelId(modelId): boolean`
 
@@ -769,7 +769,7 @@ API 实现的抽象基类。
 
 #### `inferThinkingMode(entry) / inferReasoningEfforts(entry) / inferDefaultReasoningEffort(entry) / inferVision(entry) / inferThinkingBudget(entry)`
 
-从目录条目推断：思考模式（`reasoning_options` 非空 → switchable，空但 `reasoning=true` → always）、思考强度列表（`effort` 类型 values）、默认强度（最高档）、视觉能力（`attachment`/`modalities`）、思考预算（`budget_tokens` 的 min/max）。
+从目录条目推断：思考模式（effort values 含 `none`/`disabled` → switchable；仅含实际强度或无选项 → always；非 effort 选项沿用 switchable）、思考强度列表（`effort` 类型 values）、默认强度（最高档）、视觉能力（`attachment`/`modalities`）、思考预算（`budget_tokens` 的 min/max）。因此不会向未声明关闭档位的 Responses 模型强行发送 `reasoning.effort="none"`。
 
 #### `clearModelsDevCache(): void`
 
@@ -1229,6 +1229,10 @@ API 返回用量数据后重渲染状态栏（主文本 = Go 用量，tooltip = 
 
 取出并清空最近一轮 Responses 流中捕获的 encrypted reasoning items，供 provider 在同一次图片代理循环的下一轮请求中放回。
 
+#### `async *createMessage(model, systemPrompt, messages, baseUrl, apiKey, signal?): AsyncGenerator<{ type: "text"; text: string }>`
+
+为 Git 提交消息生成发送 `store:false` 的 `/responses` 流式请求，使用顶层 `instructions` 和 typed input Items，并从 `response.output_text.delta` 逐块返回文本；失败事件直接抛错，取消时同步中止 reader。
+
 ### 4.14c `src/openai/responsesState.ts`
 
 校验 Responses reasoning output item 的 `id`、`summary` 与 `encrypted_content`，并用专用 VS Code DataPart MIME 编解码，使 `store:false` 请求不依赖服务端保存响应状态。
@@ -1365,7 +1369,7 @@ Anthropic 请求体。包含 `model`, `messages`, `max_tokens`, `system`, `strea
 
 #### `performCommitMsgGeneration(secrets, gitDiff, inputBox, repoPath?): Promise<void>`
 
-核心生成逻辑。构建 prompt（含自定义提示词、最近提交风格、用户输入、diff 内容），支持 `auto` 语言模式（由模型根据历史 commit 风格自动推断），创建 API 实例，流式输出提交消息到 InputBox。支持通过配置 `opencodego.commitIncludeCommitDiff` 控制风格参考中是否包含历史提交的实际代码变更（默认关闭）。支持通过配置 `opencodego.commitAttachContextFiles`（默认开启）控制是否将仓库根目录的 `AGENTS.md` 和 `README.md` 内容附加到 prompt 中作为额外上下文。在选择模型配置后浅拷贝（`{ ...config }`）再修改 `enable_thinking` 和 `max_completion_tokens`，防止对共享的自动发现配置缓存的突变。
+核心生成逻辑。构建 prompt（含自定义提示词、最近提交风格、用户输入、diff 内容），支持 `auto` 语言模式（由模型根据历史 commit 风格自动推断），根据 catalog 的 `apiMode` 创建 OpenAI Chat、OpenAI Responses 或 Anthropic API 实例，流式输出提交消息到 InputBox。支持通过配置 `opencodego.commitIncludeCommitDiff` 控制风格参考中是否包含历史提交的实际代码变更（默认关闭）。支持通过配置 `opencodego.commitAttachContextFiles`（默认开启）控制是否将仓库根目录的 `AGENTS.md` 和 `README.md` 内容附加到 prompt 中作为额外上下文。在选择模型配置后浅拷贝（`{ ...config }`）再修改 `enable_thinking` 和 `max_completion_tokens`，防止对共享的自动发现配置缓存的突变；只有 catalog 声明 `none`/`disabled` 档位时才为提交生成关闭 reasoning。
 
 #### `abortCommitGeneration(): void`
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 Integrate [OpenCode Go](https://opencode.ai/go) and optional Zen free models into GitHub Copilot Chat as a VS Code extension.
 
+The extension reads adapter metadata from models.dev and automatically routes each model through its declared OpenAI-compatible Chat Completions, OpenAI Responses, or Anthropic Messages protocol.
+
 ### Usage
 
 1. **Set API Key**: `Ctrl+Shift+P` → `OpenCodeGo: Set OpenCode Go API Key`
@@ -116,6 +118,8 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 > **本插件与 OpenCode 官方或 Anomaly 无关，也未获得其官方维护或认可。**
 
 将 [OpenCode Go](https://opencode.ai/go) 以及可选的 Zen 免费模型集成到 GitHub Copilot Chat 的 VS Code 插件。
+
+插件会读取 models.dev 的适配器元数据，自动按模型声明选择 OpenAI 兼容 Chat Completions、OpenAI Responses 或 Anthropic Messages 请求格式。
 
 ### 使用
 

--- a/package.json
+++ b/package.json
@@ -413,6 +413,7 @@
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
+		"test:api-mode": "npm run compile && node scripts/test-api-mode.mjs",
 		"test:vision-history": "npm run compile && node scripts/test-vision-history.mjs",
 		"lint": "eslint",
 		"watch": "tsc -watch -p ./",

--- a/package.json
+++ b/package.json
@@ -413,6 +413,7 @@
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
+		"test": "npm run compile && node scripts/test-api-mode.mjs && node scripts/test-responses-api.mjs && node scripts/test-vision-history.mjs && node scripts/test-anthropic-tool-result-merge.mjs",
 		"test:api-mode": "npm run compile && node scripts/test-api-mode.mjs",
 		"test:responses-api": "npm run compile && node scripts/test-responses-api.mjs",
 		"test:vision-history": "npm run compile && node scripts/test-vision-history.mjs",

--- a/package.json
+++ b/package.json
@@ -414,6 +414,7 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
 		"test:api-mode": "npm run compile && node scripts/test-api-mode.mjs",
+		"test:responses-api": "npm run compile && node scripts/test-responses-api.mjs",
 		"test:vision-history": "npm run compile && node scripts/test-vision-history.mjs",
 		"lint": "eslint",
 		"watch": "tsc -watch -p ./",

--- a/scripts/test-api-mode.mjs
+++ b/scripts/test-api-mode.mjs
@@ -28,7 +28,7 @@ Module._load = function (request, parent, isMain) {
 };
 
 try {
-    const { deduceApiModeFromCatalog } = require("../out/modelsDev.js");
+    const { deduceApiModeFromCatalog, inferThinkingMode } = require("../out/modelsDev.js");
 
     assert.equal(deduceApiModeFromCatalog("gpt-5.6-luna", "@ai-sdk/openai"), "openai-responses");
     assert.equal(deduceApiModeFromCatalog("glm-5", "@ai-sdk/openai-compatible"), "openai");
@@ -41,6 +41,17 @@ try {
     // A provider-wide adapter is passed only after the caller has checked the
     // model-level override, so the selected adapter remains deterministic.
     assert.equal(deduceApiModeFromCatalog("grok-4.5", "@ai-sdk/openai"), "openai-responses");
+
+    assert.equal(inferThinkingMode({
+        id: "gpt-5.6-luna",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["none", "low", "high"] }],
+    }), "switchable");
+    assert.equal(inferThinkingMode({
+        id: "grok-4.5",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    }), "always");
 
     console.log("api mode resolution: ok");
 } finally {

--- a/scripts/test-api-mode.mjs
+++ b/scripts/test-api-mode.mjs
@@ -28,7 +28,7 @@ Module._load = function (request, parent, isMain) {
 };
 
 try {
-    const { deduceApiModeFromCatalog, inferThinkingMode } = require("../out/modelsDev.js");
+    const { deduceApiModeFromCatalog, inferThinkingMode, inferSupportsDisablingReasoning } = require("../out/modelsDev.js");
 
     assert.equal(deduceApiModeFromCatalog("gpt-5.6-luna", "@ai-sdk/openai"), "openai-responses");
     assert.equal(deduceApiModeFromCatalog("glm-5", "@ai-sdk/openai-compatible"), "openai");
@@ -42,6 +42,9 @@ try {
     // model-level override, so the selected adapter remains deterministic.
     assert.equal(deduceApiModeFromCatalog("grok-4.5", "@ai-sdk/openai"), "openai-responses");
 
+    // Thinking mode keeps the pre-existing semantics: any reasoning_options
+    // makes the model "switchable" — disabling on Chat/Anthropic protocols is
+    // done via `thinking` flags, not via an effort value.
     assert.equal(inferThinkingMode({
         id: "gpt-5.6-luna",
         reasoning: true,
@@ -51,7 +54,35 @@ try {
         id: "grok-4.5",
         reasoning: true,
         reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    }), "switchable");
+    assert.equal(inferThinkingMode({
+        id: "plain-no-reasoning",
+        reasoning: false,
+        reasoning_options: [],
     }), "always");
+
+    // Whether a model accepts an explicit off effort value (used only by the
+    // Responses adapter to decide if `reasoning.effort: "none"` may be sent).
+    assert.equal(inferSupportsDisablingReasoning({
+        id: "gpt-5.6-luna",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["none", "low", "high"] }],
+    }), true);
+    assert.equal(inferSupportsDisablingReasoning({
+        id: "grok-4.5",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["low", "medium", "high"] }],
+    }), false);
+    assert.equal(inferSupportsDisablingReasoning({
+        id: "qwen-toggle",
+        reasoning: true,
+        reasoning_options: [{ type: "toggle" }],
+    }), true);
+    assert.equal(inferSupportsDisablingReasoning({
+        id: "always-thinking",
+        reasoning: true,
+        reasoning_options: [],
+    }), false);
 
     console.log("api mode resolution: ok");
 } finally {

--- a/scripts/test-api-mode.mjs
+++ b/scripts/test-api-mode.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const Module = require("node:module");
+const originalLoad = Module._load;
+
+const vscodeShim = {
+    workspace: {
+        getConfiguration: () => ({ get: (_key, fallback) => fallback }),
+    },
+    window: {
+        createOutputChannel: () => ({
+            debug() {},
+            info() {},
+            warn() {},
+            error() {},
+            dispose() {},
+        }),
+    },
+};
+
+Module._load = function (request, parent, isMain) {
+    if (request === "vscode") {
+        return vscodeShim;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+};
+
+try {
+    const { deduceApiModeFromCatalog } = require("../out/modelsDev.js");
+
+    assert.equal(deduceApiModeFromCatalog("gpt-5.6-luna", "@ai-sdk/openai"), "openai-responses");
+    assert.equal(deduceApiModeFromCatalog("glm-5", "@ai-sdk/openai-compatible"), "openai");
+    assert.equal(deduceApiModeFromCatalog("minimax-m3", "@ai-sdk/anthropic"), "anthropic");
+
+    // Legacy catalog fallback remains compatible with the existing family rules.
+    assert.equal(deduceApiModeFromCatalog("qwen3.7-plus", undefined, { family: "qwen" }), "anthropic");
+    assert.equal(deduceApiModeFromCatalog("unknown-model", undefined, { family: "unknown" }), "openai");
+
+    // A provider-wide adapter is passed only after the caller has checked the
+    // model-level override, so the selected adapter remains deterministic.
+    assert.equal(deduceApiModeFromCatalog("grok-4.5", "@ai-sdk/openai"), "openai-responses");
+
+    console.log("api mode resolution: ok");
+} finally {
+    Module._load = originalLoad;
+}

--- a/scripts/test-responses-api.mjs
+++ b/scripts/test-responses-api.mjs
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const Module = require("node:module");
 const originalLoad = Module._load;
+const originalFetch = globalThis.fetch;
 
 class DataPart {
     constructor(data, mimeType) {
@@ -43,6 +44,8 @@ const vscodeShim = {
     LanguageModelToolResultPart: ToolResultPart,
     LanguageModelThinkingPart: ThinkingPart,
     LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+    extensions: { getExtension: () => undefined },
+    version: "test",
     workspace: { getConfiguration: () => ({ get: (_key, fallback) => fallback }) },
     window: {
         createOutputChannel: () => ({
@@ -138,6 +141,18 @@ try {
     });
     assert.equal(body.tool_choice, "required");
 
+    const noReasoningBody = api.prepareRequestBody(
+        { model: "plain-model", input: [], stream: true, store: false },
+        {
+            id: "plain-model",
+            owned_by: "opencode",
+            supportsReasoning: false,
+            enable_thinking: false,
+        },
+    );
+    assert.equal("reasoning" in noReasoningBody, false);
+    assert.equal("include" in noReasoningBody, false);
+
     const streamed = [];
     let usage;
     api.onUsage = (value) => { usage = value; };
@@ -223,7 +238,43 @@ try {
         { role: "assistant", content: [{ type: "output_text", text: "Prior answer" }] },
     ]);
 
+    let capturedRequest;
+    globalThis.fetch = async (url, init) => {
+        capturedRequest = { url: String(url), init };
+        return new Response(makeStream([
+            { type: "response.output_text.delta", delta: "feat: " },
+            { type: "response.output_text.delta", delta: "support responses" },
+            { type: "response.completed", response: { usage: { input_tokens: 5, output_tokens: 3 } } },
+        ]), { status: 200 });
+    };
+    const commitChunks = [];
+    for await (const chunk of new ResponsesApi("gpt-5.6-luna").createMessage(
+        {
+            id: "gpt-5.6-luna",
+            owned_by: "opencode",
+            apiMode: "openai-responses",
+            enable_thinking: false,
+        },
+        "Generate one commit subject.",
+        [{ role: "user", content: "diff --git a/a b/a" }],
+        "https://example.test/v1/",
+        "test-token",
+    )) {
+        commitChunks.push(chunk.text);
+    }
+    assert.deepEqual(commitChunks, ["feat: ", "support responses"]);
+    assert.equal(capturedRequest.url, "https://example.test/v1/responses");
+    assert.equal(capturedRequest.init.headers.Authorization, "Bearer test-token");
+    const commitBody = JSON.parse(capturedRequest.init.body);
+    assert.equal(commitBody.store, false);
+    assert.equal(commitBody.instructions, "Generate one commit subject.");
+    assert.deepEqual(commitBody.reasoning, { effort: "none" });
+    assert.deepEqual(commitBody.input, [
+        { role: "user", content: [{ type: "input_text", text: "diff --git a/a b/a" }] },
+    ]);
+
     console.log("responses api: ok");
 } finally {
     Module._load = originalLoad;
+    globalThis.fetch = originalFetch;
 }

--- a/scripts/test-responses-api.mjs
+++ b/scripts/test-responses-api.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const Module = require("node:module");
+const originalLoad = Module._load;
+
+class DataPart {
+    constructor(data, mimeType) {
+        this.data = data;
+        this.mimeType = mimeType;
+    }
+}
+class TextPart {
+    constructor(value) {
+        this.value = value;
+    }
+}
+class ToolCallPart {
+    constructor(callId, name, input) {
+        this.callId = callId;
+        this.name = name;
+        this.input = input;
+    }
+}
+class ToolResultPart {
+    constructor(callId, content) {
+        this.callId = callId;
+        this.content = content;
+    }
+}
+class ThinkingPart {
+    constructor(value, id) {
+        this.value = value;
+        this.id = id;
+    }
+}
+
+const vscodeShim = {
+    LanguageModelDataPart: DataPart,
+    LanguageModelTextPart: TextPart,
+    LanguageModelToolCallPart: ToolCallPart,
+    LanguageModelToolResultPart: ToolResultPart,
+    LanguageModelThinkingPart: ThinkingPart,
+    LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+    workspace: { getConfiguration: () => ({ get: (_key, fallback) => fallback }) },
+    window: {
+        createOutputChannel: () => ({
+            debug() {},
+            info() {},
+            warn() {},
+            error() {},
+            dispose() {},
+        }),
+    },
+};
+
+Module._load = function (request, parent, isMain) {
+    if (request === "vscode") return vscodeShim;
+    return originalLoad.call(this, request, parent, isMain);
+};
+
+const makeStream = (events) => {
+    const encoded = new TextEncoder().encode(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+    const split = Math.floor(encoded.length / 2);
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(encoded.slice(0, split));
+            controller.enqueue(encoded.slice(split));
+            controller.close();
+        },
+    });
+};
+
+try {
+    const { logger } = require("../out/logger.js");
+    logger.init();
+    const { ResponsesApi } = require("../out/openai/responsesApi.js");
+
+    const api = new ResponsesApi("gpt-5.6-luna");
+    const messages = [
+        { role: 3, content: [new TextPart("System rules")] },
+        { role: 1, content: [new TextPart("Inspect this"), new DataPart(new Uint8Array([1, 2]), "image/png")] },
+        {
+            role: 2,
+            content: [
+                new TextPart("I will read it."),
+                new ToolCallPart("call_read", "read_file", { filePath: "/tmp/a" }),
+            ],
+        },
+        { role: 1, content: [new ToolResultPart("call_read", [new TextPart("file contents")])] },
+    ];
+    const input = await api.convertMessages(messages, { includeReasoningInRequest: true, vision: true });
+    assert.deepEqual(input[0], { role: "system", content: "System rules" });
+    assert.equal(input[1].role, "user");
+    assert.deepEqual(input[1].content[0], { type: "input_text", text: "Inspect this" });
+    assert.equal(input[1].content[1].type, "input_image");
+    assert.deepEqual(input[2], {
+        role: "assistant",
+        content: [{ type: "output_text", text: "I will read it." }],
+    });
+    assert.deepEqual(input[3], {
+        type: "function_call",
+        call_id: "call_read",
+        name: "read_file",
+        arguments: JSON.stringify({ filePath: "/tmp/a" }),
+    });
+    assert.deepEqual(input[4], {
+        type: "function_call_output",
+        call_id: "call_read",
+        output: "file contents",
+    });
+
+    const body = api.prepareRequestBody(
+        { model: "gpt-5.6-luna", input, stream: true, store: false },
+        {
+            id: "gpt-5.6-luna",
+            owned_by: "opencode",
+            max_completion_tokens: 2048,
+            reasoning_effort: "high",
+            enable_thinking: true,
+        },
+        {
+            tools: [{ name: "read_file", description: "Read a file", inputSchema: { type: "object" } }],
+            modelOptions: { toolMode: "required" },
+        },
+    );
+    assert.equal(body.max_output_tokens, 2048);
+    assert.deepEqual(body.reasoning, { effort: "high", summary: "auto" });
+    assert.deepEqual(body.include, ["reasoning.encrypted_content"]);
+    assert.deepEqual(body.tools?.[0], {
+        type: "function",
+        name: "read_file",
+        description: "Read a file",
+        parameters: { type: "object" },
+        strict: false,
+    });
+    assert.equal(body.tool_choice, "required");
+
+    const streamed = [];
+    let usage;
+    api.onUsage = (value) => { usage = value; };
+    await api.processStreamingResponse(
+        makeStream([
+            { type: "response.reasoning_summary_text.delta", delta: "Checking" },
+            { type: "response.output_text.delta", delta: "Done" },
+            {
+                type: "response.output_item.added",
+                output_index: 1,
+                item: { type: "function_call", id: "item_1", call_id: "call_1", name: "read_file", arguments: "" },
+            },
+            { type: "response.function_call_arguments.delta", output_index: 1, item_id: "item_1", delta: "{\"filePath\":" },
+            { type: "response.function_call_arguments.delta", output_index: 1, item_id: "item_1", delta: "\"/tmp/a\"}" },
+            {
+                type: "response.output_item.done",
+                output_index: 1,
+                item: { type: "function_call", id: "item_1", call_id: "call_1", name: "read_file", arguments: "{\"filePath\":\"/tmp/a\"}" },
+            },
+            {
+                type: "response.completed",
+                response: {
+                    usage: { input_tokens: 10, output_tokens: 4, input_tokens_details: { cached_tokens: 3 } },
+                },
+            },
+        ]),
+        { report: (part) => streamed.push(part) },
+        {
+            isCancellationRequested: false,
+            onCancellationRequested: () => ({ dispose() {} }),
+        },
+    );
+
+    assert.ok(streamed.some((part) => part instanceof TextPart && part.value === "Done"));
+    const toolParts = streamed.filter((part) => part instanceof ToolCallPart);
+    assert.equal(toolParts.length, 1, "streamed tool call must be emitted exactly once");
+    assert.deepEqual(toolParts[0].input, { filePath: "/tmp/a" });
+    assert.deepEqual(usage, {
+        promptTokens: 10,
+        completionTokens: 4,
+        cacheHitTokens: 3,
+        cacheMissTokens: 7,
+    });
+
+    console.log("responses api: ok");
+} finally {
+    Module._load = originalLoad;
+}

--- a/scripts/test-responses-api.mjs
+++ b/scripts/test-responses-api.mjs
@@ -153,6 +153,35 @@ try {
     assert.equal("reasoning" in noReasoningBody, false);
     assert.equal("include" in noReasoningBody, false);
 
+    // A Responses model that does not declare an off effort value must NOT be
+    // sent `reasoning.effort: "none"`; reasoning controls are omitted instead.
+    const noNoneEffortBody = api.prepareRequestBody(
+        { model: "grok-4.5", input: [], stream: true, store: false },
+        {
+            id: "grok-4.5",
+            owned_by: "opencode",
+            supportsReasoning: true,
+            supportsDisablingReasoning: false,
+            enable_thinking: false,
+        },
+    );
+    assert.equal("reasoning" in noNoneEffortBody, false);
+    assert.equal("include" in noNoneEffortBody, false);
+
+    // A Responses model that declares `none`/`disabled` still gets the off
+    // effort when thinking is disabled.
+    const noneEffortBody = api.prepareRequestBody(
+        { model: "gpt-5.6-luna", input: [], stream: true, store: false },
+        {
+            id: "gpt-5.6-luna",
+            owned_by: "opencode",
+            supportsReasoning: true,
+            supportsDisablingReasoning: true,
+            enable_thinking: false,
+        },
+    );
+    assert.deepEqual(noneEffortBody.reasoning, { effort: "none" });
+
     const streamed = [];
     let usage;
     api.onUsage = (value) => { usage = value; };
@@ -253,6 +282,7 @@ try {
             id: "gpt-5.6-luna",
             owned_by: "opencode",
             apiMode: "openai-responses",
+            supportsDisablingReasoning: true,
             enable_thinking: false,
         },
         "Generate one commit subject.",

--- a/scripts/test-responses-api.mjs
+++ b/scripts/test-responses-api.mjs
@@ -76,6 +76,7 @@ try {
     const { logger } = require("../out/logger.js");
     logger.init();
     const { ResponsesApi } = require("../out/openai/responsesApi.js");
+    const { RESPONSES_REASONING_MIME } = require("../out/openai/responsesState.js");
 
     const api = new ResponsesApi("gpt-5.6-luna");
     const messages = [
@@ -157,6 +158,16 @@ try {
                 item: { type: "function_call", id: "item_1", call_id: "call_1", name: "read_file", arguments: "{\"filePath\":\"/tmp/a\"}" },
             },
             {
+                type: "response.output_item.done",
+                output_index: 0,
+                item: {
+                    type: "reasoning",
+                    id: "rs_1",
+                    summary: [{ type: "summary_text", text: "Checking" }],
+                    encrypted_content: "encrypted-reasoning-state",
+                },
+            },
+            {
                 type: "response.completed",
                 response: {
                     usage: { input_tokens: 10, output_tokens: 4, input_tokens_details: { cached_tokens: 3 } },
@@ -180,6 +191,37 @@ try {
         cacheHitTokens: 3,
         cacheMissTokens: 7,
     });
+
+    const reasoningParts = streamed.filter(
+        (part) => part instanceof DataPart && part.mimeType === RESPONSES_REASONING_MIME,
+    );
+    assert.equal(reasoningParts.length, 1, "encrypted reasoning state must be emitted exactly once");
+    assert.deepEqual(api.takeCapturedReasoningItems(), [
+        {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [{ type: "summary_text", text: "Checking" }],
+            encrypted_content: "encrypted-reasoning-state",
+        },
+    ]);
+    assert.deepEqual(api.takeCapturedReasoningItems(), [], "captured reasoning state must be drained");
+
+    const replayed = await new ResponsesApi("gpt-5.6-luna").convertMessages(
+        [
+            { role: 2, content: [reasoningParts[0], new TextPart("Prior answer")] },
+            { role: 1, content: [new TextPart("Continue")] },
+        ],
+        { includeReasoningInRequest: true, vision: false },
+    );
+    assert.deepEqual(replayed.slice(0, 2), [
+        {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [{ type: "summary_text", text: "Checking" }],
+            encrypted_content: "encrypted-reasoning-state",
+        },
+        { role: "assistant", content: [{ type: "output_text", text: "Prior answer" }] },
+    ]);
 
     console.log("responses api: ok");
 } finally {

--- a/scripts/test-vision-history.mjs
+++ b/scripts/test-vision-history.mjs
@@ -5,6 +5,7 @@ import {
     serializeVisionToolHistory,
     toAnthropicVisionToolMessages,
     toOpenAIVisionToolMessages,
+    toResponsesVisionToolItems,
 } from "../out/vision/historyCodec.js";
 
 const entry = {
@@ -38,6 +39,19 @@ assert.deepEqual(toAnthropicVisionToolMessages(entry), [
     {
         role: "user",
         content: [{ type: "tool_result", tool_use_id: entry.id, content: entry.result }],
+    },
+]);
+assert.deepEqual(toResponsesVisionToolItems(entry), [
+    {
+        type: "function_call",
+        call_id: entry.id,
+        name: entry.name,
+        arguments: JSON.stringify(entry.args),
+    },
+    {
+        type: "function_call_output",
+        call_id: entry.id,
+        output: entry.result,
     },
 ]);
 assert.equal(deserializeVisionToolHistory(new TextEncoder().encode("not-json")), null);
@@ -85,6 +99,7 @@ Module._load = function (request, parent, isMain) {
 try {
     const { createVisionToolHistoryPart } = require("../out/vision/historyPart.js");
     const { OpenaiApi } = require("../out/openai/openaiApi.js");
+    const { ResponsesApi } = require("../out/openai/responsesApi.js");
     const { AnthropicApi } = require("../out/anthropic/anthropicApi.js");
     const persistedPart = createVisionToolHistoryPart(entry);
     const nextTurnMessages = [
@@ -124,6 +139,25 @@ try {
             content: [{ type: "tool_result", tool_use_id: entry.id, content: entry.result }],
         },
         { role: "assistant", content: [{ type: "text", text: "The previous answer." }, { type: "thinking", thinking: "Next step." }] },
+    ]);
+
+    const responsesItems = await new ResponsesApi("test").convertMessages(nextTurnMessages, {
+        includeReasoningInRequest: true,
+        vision: false,
+    });
+    assert.deepEqual(responsesItems.slice(0, 3), [
+        {
+            type: "function_call",
+            call_id: entry.id,
+            name: entry.name,
+            arguments: JSON.stringify(entry.args),
+        },
+        {
+            type: "function_call_output",
+            call_id: entry.id,
+            output: entry.result,
+        },
+        { role: "assistant", content: [{ type: "output_text", text: "The previous answer." }] },
     ]);
 
     // A tool-call assistant message WITHOUT any reasoning parts must still carry

--- a/src/catalogModels.ts
+++ b/src/catalogModels.ts
@@ -25,6 +25,7 @@ import {
     getCatalogProviderModelIds,
     inferDefaultReasoningEffort,
     inferReasoningEfforts,
+    inferSupportsDisablingReasoning,
     inferThinkingBudget,
     inferThinkingMode,
     inferVision,
@@ -58,6 +59,8 @@ export interface ModelMeta {
     displayName: string;
     vision: boolean;
     reasoning: boolean;
+    /** Whether the model declares an explicit off value for reasoning effort (used by the Responses adapter). */
+    supportsDisablingReasoning: boolean;
     thinkingMode: "switchable" | "always" | "adaptive";
     supportedReasoningEfforts: string[];
     defaultReasoningEffort: string;
@@ -117,6 +120,7 @@ function resolveFromCatalog(providerId: ProviderId, modelId: string): ModelMeta 
         displayName: entry?.name ?? modelId,
         vision: entry ? inferVision(entry) : false,
         reasoning: entry?.reasoning ?? false,
+        supportsDisablingReasoning: entry ? inferSupportsDisablingReasoning(entry) : true,
         thinkingMode,
         supportedReasoningEfforts,
         defaultReasoningEffort: entry ? inferDefaultReasoningEffort(entry) : "enabled",
@@ -141,6 +145,7 @@ function applyOverride(meta: ModelMeta, override?: ModelMetaOverride): ModelMeta
         displayName: override.displayName ?? meta.displayName,
         vision: override.vision ?? meta.vision,
         reasoning: meta.reasoning,
+        supportsDisablingReasoning: override.supportsDisablingReasoning ?? meta.supportsDisablingReasoning,
         thinkingMode: override.thinkingMode ?? meta.thinkingMode,
         supportedReasoningEfforts: override.supportedReasoningEfforts ?? meta.supportedReasoningEfforts,
         defaultReasoningEffort: override.defaultReasoningEffort ?? meta.defaultReasoningEffort,
@@ -173,10 +178,19 @@ function buildReasoningEnum(meta: ModelMeta): {
     defaultEffort: string;
 } {
     const hasEfforts = meta.supportedReasoningEfforts.length > 0;
+    // A Responses-native model that does not declare an off effort value cannot
+    // accept `reasoning.effort: "none"`; hide the "disabled" option for it so
+    // users do not pick an ineffective off switch. Other protocols disable
+    // thinking via `thinking: { type: "disabled" }` regardless of the effort
+    // list, so they keep the "disabled" option.
+    const canShowDisabled =
+        meta.apiMode !== "openai-responses" || meta.supportsDisablingReasoning !== false;
     let enumValues: string[];
     if (hasEfforts) {
         if (meta.thinkingMode === "switchable") {
-            enumValues = ["disabled", ...meta.supportedReasoningEfforts];
+            enumValues = canShowDisabled
+                ? ["disabled", ...meta.supportedReasoningEfforts]
+                : [...meta.supportedReasoningEfforts];
         } else {
             enumValues = [...meta.supportedReasoningEfforts];
         }
@@ -353,6 +367,7 @@ export function getCatalogModelConfig(modelId: string): OpenCodeGoModelItem {
         max_completion_tokens: meta.maxOutputTokens,
         apiMode: meta.apiMode,
         supportsReasoning: meta.reasoning,
+        supportsDisablingReasoning: meta.supportsDisablingReasoning,
         enable_thinking: true,
         include_reasoning_in_request: override?.includeReasoningInRequest ?? true,
         thinkingMode: meta.thinkingMode,

--- a/src/catalogModels.ts
+++ b/src/catalogModels.ts
@@ -13,12 +13,13 @@
  */
 
 import type { LanguageModelChatInformation } from "vscode";
-import type { OpenCodeGoModelItem } from "./types";
+import type { ApiMode, OpenCodeGoModelItem } from "./types";
 import { l10n } from "./localize";
 import { MODEL_OVERRIDES, type ModelMetaOverride } from "./modelOverrides";
 import {
-    deduceApiModeFromFamily,
+    deduceApiModeFromCatalog,
     ensureModelsDevLoaded,
+    getCatalogProvider,
     getCatalogProviderBaseUrl,
     getCatalogProviderModelEntry,
     getCatalogProviderModelIds,
@@ -61,7 +62,7 @@ export interface ModelMeta {
     defaultReasoningEffort: string;
     contextLength: number;
     maxOutputTokens: number;
-    apiMode: "openai" | "anthropic";
+    apiMode: ApiMode;
     supportsTemperature: boolean;
     toolCalling: boolean;
     baseUrl: string;
@@ -103,6 +104,8 @@ function resolveFromCatalog(providerId: ProviderId, modelId: string): ModelMeta 
     const providerEntry = getCatalogProviderModelEntry(providerId, modelId);
     const globalEntry = lookupModelDevEntry(modelId);
     const entry: ModelsDevEntry | undefined = providerEntry ?? globalEntry;
+    const providerNpm = getCatalogProvider(providerId)?.npm;
+    const adapterNpm = providerEntry?.provider?.npm ?? providerNpm;
 
     const thinkingMode = entry ? inferThinkingMode(entry) : "switchable";
     const rawEfforts = entry ? inferReasoningEfforts(entry) : undefined;
@@ -117,7 +120,7 @@ function resolveFromCatalog(providerId: ProviderId, modelId: string): ModelMeta 
         defaultReasoningEffort: entry ? inferDefaultReasoningEffort(entry) : "enabled",
         contextLength: entry?.limit?.context ?? DEFAULT_CONTEXT_LENGTH,
         maxOutputTokens: entry?.limit?.output ?? DEFAULT_MAX_TOKENS,
-        apiMode: entry ? deduceApiModeFromFamily(modelId, entry) : "openai",
+        apiMode: deduceApiModeFromCatalog(modelId, adapterNpm, entry),
         supportsTemperature: entry?.temperature ?? true,
         toolCalling: entry?.tool_call ?? true,
         baseUrl: getCatalogProviderBaseUrl(providerId, FALLBACK_BASE_URLS[providerId]),

--- a/src/catalogModels.ts
+++ b/src/catalogModels.ts
@@ -57,6 +57,7 @@ const DEFAULT_MAX_TOKENS = 4096;
 export interface ModelMeta {
     displayName: string;
     vision: boolean;
+    reasoning: boolean;
     thinkingMode: "switchable" | "always" | "adaptive";
     supportedReasoningEfforts: string[];
     defaultReasoningEffort: string;
@@ -115,6 +116,7 @@ function resolveFromCatalog(providerId: ProviderId, modelId: string): ModelMeta 
     return {
         displayName: entry?.name ?? modelId,
         vision: entry ? inferVision(entry) : false,
+        reasoning: entry?.reasoning ?? false,
         thinkingMode,
         supportedReasoningEfforts,
         defaultReasoningEffort: entry ? inferDefaultReasoningEffort(entry) : "enabled",
@@ -138,6 +140,7 @@ function applyOverride(meta: ModelMeta, override?: ModelMetaOverride): ModelMeta
     return {
         displayName: override.displayName ?? meta.displayName,
         vision: override.vision ?? meta.vision,
+        reasoning: meta.reasoning,
         thinkingMode: override.thinkingMode ?? meta.thinkingMode,
         supportedReasoningEfforts: override.supportedReasoningEfforts ?? meta.supportedReasoningEfforts,
         defaultReasoningEffort: override.defaultReasoningEffort ?? meta.defaultReasoningEffort,
@@ -349,6 +352,7 @@ export function getCatalogModelConfig(modelId: string): OpenCodeGoModelItem {
         context_length: meta.contextLength,
         max_completion_tokens: meta.maxOutputTokens,
         apiMode: meta.apiMode,
+        supportsReasoning: meta.reasoning,
         enable_thinking: true,
         include_reasoning_in_request: override?.includeReasoningInRequest ?? true,
         thinkingMode: meta.thinkingMode,

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -8,7 +8,7 @@ import {
     Progress,
     CancellationToken,
 } from "vscode";
-import { OpenCodeGoModelItem } from "./types";
+import type { ApiMode, OpenCodeGoModelItem } from "./types";
 import { tryParseJSONObject } from "./utils";
 import { VersionManager } from "./versionManager";
 import type { InterceptedToolCall, StoredImage } from "./vision/types";
@@ -432,7 +432,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      */
     public static prepareHeaders(
         apiKey: string,
-        apiMode: string,
+        apiMode: ApiMode,
         customHeaders?: Record<string, string>
     ): Record<string, string> {
         // Internal override for testing or contingency (e.g. if the API ever gates access by User-Agent again).

--- a/src/gitCommit/commitMessageGenerator.ts
+++ b/src/gitCommit/commitMessageGenerator.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { getGitDiff, getRecentCommits } from "./gitUtils";
 import { OpenaiApi } from "../openai/openaiApi";
+import { ResponsesApi } from "../openai/responsesApi";
 import { AnthropicApi } from "../anthropic/anthropicApi";
 import { getCatalogModelConfig } from "../catalogModels";
 import { getCatalogProviderBaseUrl } from "../modelsDev";
@@ -227,8 +228,11 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
         const selectedModel: OpenCodeGoModelItem = {
             ...getCatalogModelConfig(commitModelId)
         };
-        // Commit messages are simple tasks — disable thinking to speed up generation.
-        selectedModel.enable_thinking = false;
+        // Commit messages are simple tasks — disable thinking when the catalog
+        // says the model supports a disabled/none reasoning mode.
+        if (selectedModel.thinkingMode !== "always") {
+            selectedModel.enable_thinking = false;
+        }
         // Cap max_completion_tokens to avoid proxy 500 errors with oversized values
         if (selectedModel.max_completion_tokens && selectedModel.max_completion_tokens > 8192) {
             selectedModel.max_completion_tokens = 8192;
@@ -272,7 +276,9 @@ async function performCommitMsgGeneration(secrets: vscode.SecretStorage, gitDiff
 
         const apiInstance = apiMode === "anthropic"
             ? new AnthropicApi(modelId)
-            : new OpenaiApi(modelId);
+            : apiMode === "openai-responses"
+                ? new ResponsesApi(modelId)
+                : new OpenaiApi(modelId);
 
         commitGenerationAbortController = new AbortController();
         const stream = apiInstance.createMessage(selectedModel, systemPrompt, messages, baseUrl, apiKey, commitGenerationAbortController.signal);

--- a/src/modelOverrides.ts
+++ b/src/modelOverrides.ts
@@ -29,6 +29,8 @@ export interface ModelMetaOverride {
     apiMode?: ApiMode;
     supportsTemperature?: boolean;
     toolCalling?: boolean;
+    /** Override whether the model accepts an explicit off effort value (`none`/`disabled`) on the Responses protocol. */
+    supportsDisablingReasoning?: boolean;
     baseUrl?: string;
     /** Fields the catalog cannot express: request-body extras (e.g. reasoning_split) */
     extra?: Record<string, unknown>;

--- a/src/modelOverrides.ts
+++ b/src/modelOverrides.ts
@@ -12,6 +12,8 @@
  * otherwise the value resolved from the catalog is used.
  */
 
+import type { ApiMode } from "./types";
+
 /**
  * Override for a single model. Every field is optional — only the fields
  * written here take effect; everything else falls through to the catalog.
@@ -24,7 +26,7 @@ export interface ModelMetaOverride {
     defaultReasoningEffort?: string;
     contextLength?: number;
     maxOutputTokens?: number;
-    apiMode?: "openai" | "anthropic";
+    apiMode?: ApiMode;
     supportsTemperature?: boolean;
     toolCalling?: boolean;
     baseUrl?: string;

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -24,6 +24,7 @@
 import * as vscode from "vscode";
 import { HARDCODED_CATALOG } from "./hardcodedModelList";
 import { logger } from "./logger";
+import type { ApiMode } from "./types";
 
 const CATALOG_URL = "https://models.dev/catalog.json";
 const CACHE_TTL_MS = 60 * 1000; // 1 minute — dedupes concurrent startup activations
@@ -480,14 +481,24 @@ export function hasModelDevEntry(apiModelId: string): boolean {
 }
 
 /**
- * Deduce API mode (openai vs anthropic) from a model ID and optional catalog entry.
- * Uses family-based heuristics since the catalog does not directly expose apiMode.
- *
- * Also checks the `provider.npm` field: @ai-sdk/anthropic → anthropic.
+ * Resolve the request protocol from the models.dev adapter package.
+ * The provider-specific model override is selected by the caller before the
+ * provider-wide default. Family heuristics are retained only for legacy or
+ * incomplete catalogs that do not expose a recognized adapter package.
  */
-export function deduceApiModeFromFamily(modelId: string, entry?: ModelsDevEntry): "openai" | "anthropic" {
-    // Check provider npm hint first
-    if (entry?.provider?.npm?.includes("anthropic")) return "anthropic";
+export function deduceApiModeFromCatalog(
+    modelId: string,
+    adapterNpm?: string,
+    entry?: ModelsDevEntry
+): ApiMode {
+    switch (adapterNpm) {
+        case "@ai-sdk/openai":
+            return "openai-responses";
+        case "@ai-sdk/anthropic":
+            return "anthropic";
+        case "@ai-sdk/openai-compatible":
+            return "openai";
+    }
 
     const family = entry?.family?.toLowerCase() ?? "";
     if (family.includes("claude") || family.includes("anthropic")) return "anthropic";

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -309,12 +309,20 @@ export function getCatalogProviderModelIds(providerId: string): string[] {
  *
  * - `reasoning: false` or missing → `"always"` (no thinking at all)
  * - `reasoning_options` is empty or missing → `"always"` (thinking always on, no user control)
- * - `reasoning_options` has entries → `"switchable"` (user can toggle)
+ * - effort values include `none`/`disabled` → `"switchable"`
+ * - effort values omit a disabled value → `"always"`
+ * - non-effort options keep the legacy `"switchable"` behavior
  */
 export function inferThinkingMode(entry: ModelsDevEntry): "switchable" | "always" | "adaptive" {
     if (!entry.reasoning) return "always";
     const opts = entry.reasoning_options;
     if (!opts || opts.length === 0) return "always";
+    const effortOption = opts.find((option) => option.type === "effort" && option.values?.length);
+    if (effortOption?.values) {
+        return effortOption.values.some((value) => value === "none" || value === "disabled")
+            ? "switchable"
+            : "always";
+    }
     return "switchable";
 }
 

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -309,21 +309,48 @@ export function getCatalogProviderModelIds(providerId: string): string[] {
  *
  * - `reasoning: false` or missing → `"always"` (no thinking at all)
  * - `reasoning_options` is empty or missing → `"always"` (thinking always on, no user control)
- * - effort values include `none`/`disabled` → `"switchable"`
- * - effort values omit a disabled value → `"always"`
- * - non-effort options keep the legacy `"switchable"` behavior
+ * - `reasoning_options` has entries → `"switchable"` (user can toggle / pick effort)
+ *
+ * Note: whether a model accepts an explicit off switch (`effort: "none"`) on a
+ * given protocol is a separate concern; that capability is exposed through
+ * `inferSupportsDisablingReasoning()` (used by the Responses adapter), so the
+ * generic thinking mode keeps the pre-existing semantics for Chat/Anthropic
+ * protocols (which disable thinking via `thinking: { type: "disabled" }`, not
+ * via an effort value).
  */
 export function inferThinkingMode(entry: ModelsDevEntry): "switchable" | "always" | "adaptive" {
     if (!entry.reasoning) return "always";
     const opts = entry.reasoning_options;
     if (!opts || opts.length === 0) return "always";
-    const effortOption = opts.find((option) => option.type === "effort" && option.values?.length);
-    if (effortOption?.values) {
-        return effortOption.values.some((value) => value === "none" || value === "disabled")
-            ? "switchable"
-            : "always";
-    }
     return "switchable";
+}
+
+/**
+ * Whether the catalog declares that the model can accept an explicit off
+ * value for reasoning effort (`"none"` / `"disabled"`).
+ *
+ * - effort list includes `none`/`disabled` → `true`
+ * - toggle-style option (simple on/off) → `true`
+ * - effort list omits a disabled value → `false`
+ * - no reasoning options at all → `false`
+ *
+ * This is used ONLY by the OpenAI Responses protocol adapter: sending
+ * `reasoning.effort: "none"` to a Responses model that does not declare such a
+ * value can be rejected by the endpoint. Chat Completions / Anthropic
+ * protocols disable thinking independently of this (via `thinking` flags).
+ */
+export function inferSupportsDisablingReasoning(entry: ModelsDevEntry): boolean {
+    const opts = entry.reasoning_options;
+    if (!opts || opts.length === 0 || !entry.reasoning) return false;
+    for (const opt of opts) {
+        if (opt.type === "effort" && opt.values?.length) {
+            return opt.values.some((value) => value === "none" || value === "disabled");
+        }
+        if (opt.type === "toggle") {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**

--- a/src/openai/responsesApi.ts
+++ b/src/openai/responsesApi.ts
@@ -1,0 +1,411 @@
+import * as vscode from "vscode";
+import {
+    CancellationToken,
+    LanguageModelChatRequestMessage,
+    LanguageModelResponsePart,
+    Progress,
+    ProvideLanguageModelChatResponseOptions,
+} from "vscode";
+
+import { CommonApi, type StreamUsage } from "../commonApi";
+import type { OpenCodeGoModelItem } from "../types";
+import {
+    createDataUrl,
+    convertOpenAIToolToResponses,
+    convertToolsToResponses,
+    isImageMimeType,
+    isResourceLinkMimeType,
+    isToolResultPart,
+    mapRole,
+    parseResourceLinkData,
+    replaceDataUriImages,
+    resolveResourceLinkToImage,
+    storeDataUriImages,
+} from "../utils";
+import { logger } from "../logger";
+import type { StoredImage } from "../vision/types";
+import { ASK_IMAGE_TOOL_DEF, ASK_WITH_MULTI_IMAGE_TOOL_DEF } from "../vision/types";
+import type { OpenAIFunctionToolDef } from "./openaiTypes";
+import type {
+    ResponsesFunctionCallItem,
+    ResponsesFunctionCallOutputItem,
+    ResponsesInputContent,
+    ResponsesInputItem,
+    ResponsesRequestBody,
+    ResponsesStreamEvent,
+    ResponsesStreamItem,
+    ResponsesUsage,
+} from "./responsesTypes";
+
+const imageDirective = (imageIndex: number): string =>
+    `\n[The user sent an image (imageIndex=${imageIndex}). I am a text-only model and CANNOT see images directly. I MUST call the ask_image tool to learn about it.\n\nRecommended strategy:\n1. First call ask_image for a brief description to get an overview of the image.\n2. Then call ask_image again with specific questions about details you need (e.g., colors, text content, UI elements, error messages, or any other visible information).\n]`;
+
+/** OpenAI Responses protocol adapter. */
+export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequestBody> {
+    private _hasImages = false;
+
+    constructor(modelId: string) {
+        super(modelId);
+    }
+
+    /** Convert VS Code request messages into Responses input items. */
+    async convertMessages(
+        messages: readonly LanguageModelChatRequestMessage[],
+        modelConfig: { includeReasoningInRequest: boolean; vision?: boolean }
+    ): Promise<ResponsesInputItem[]> {
+        const modelSupportsVision = modelConfig.vision !== false;
+        const out: ResponsesInputItem[] = [];
+        let imageIndex = 0;
+
+        if (!modelSupportsVision) {
+            const imagesToStore: StoredImage[] = [];
+            for (const message of messages) {
+                for (const part of message.content ?? []) {
+                    if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
+                        imagesToStore.push({ data: part.data, mimeType: part.mimeType });
+                    } else if (part instanceof vscode.LanguageModelTextPart) {
+                        storeDataUriImages(part.value, imagesToStore);
+                    } else if (isToolResultPart(part)) {
+                        for (const inner of (part as { content?: ReadonlyArray<unknown> }).content ?? []) {
+                            if (inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
+                                imagesToStore.push({ data: inner.data, mimeType: inner.mimeType });
+                            } else if (inner instanceof vscode.LanguageModelTextPart) {
+                                storeDataUriImages(inner.value, imagesToStore);
+                            } else if (inner instanceof vscode.LanguageModelDataPart && isResourceLinkMimeType(inner.mimeType)) {
+                                const stored = await resolveResourceLinkToImage(inner.data);
+                                if (stored) imagesToStore.push(stored);
+                            }
+                        }
+                    }
+                }
+            }
+            if (imagesToStore.length > 0) {
+                this._localImages = imagesToStore;
+                this._hasImages = true;
+            }
+        }
+
+        for (const message of messages) {
+            const role = mapRole(message);
+            const textParts: string[] = [];
+            const imageParts: vscode.LanguageModelDataPart[] = [];
+            const toolCalls: ResponsesFunctionCallItem[] = [];
+            const toolResults: ResponsesFunctionCallOutputItem[] = [];
+
+            for (const part of message.content ?? []) {
+                if (part instanceof vscode.LanguageModelTextPart) {
+                    if (modelSupportsVision) {
+                        textParts.push(part.value);
+                    } else {
+                        const replaced = replaceDataUriImages(part.value, imageIndex);
+                        imageIndex += replaced.count;
+                        textParts.push(replaced.text);
+                    }
+                } else if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
+                    if (modelSupportsVision) {
+                        imageParts.push(part);
+                    } else {
+                        textParts.push(imageDirective(imageIndex++));
+                    }
+                } else if (part instanceof vscode.LanguageModelToolCallPart) {
+                    const callId = part.callId || `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+                    let args = "{}";
+                    try {
+                        args = JSON.stringify(part.input ?? {});
+                    } catch {
+                        // Keep a valid empty object when tool input is not serializable.
+                    }
+                    toolCalls.push({
+                        type: "function_call",
+                        call_id: callId,
+                        name: part.name,
+                        arguments: args,
+                    });
+                } else if (isToolResultPart(part)) {
+                    const callId = (part as { callId?: string }).callId ?? "";
+                    const resultText: string[] = [];
+                    const resultImages: ResponsesInputContent[] = [];
+                    for (const inner of (part as { content?: ReadonlyArray<unknown> }).content ?? []) {
+                        if (inner instanceof vscode.LanguageModelTextPart) {
+                            if (modelSupportsVision) {
+                                resultText.push(inner.value);
+                            } else {
+                                const replaced = replaceDataUriImages(inner.value, imageIndex);
+                                imageIndex += replaced.count;
+                                resultText.push(replaced.text);
+                            }
+                        } else if (inner instanceof vscode.LanguageModelDataPart && isImageMimeType(inner.mimeType)) {
+                            if (modelSupportsVision) {
+                                resultImages.push({ type: "input_image", image_url: createDataUrl(inner) });
+                            } else {
+                                resultText.push(imageDirective(imageIndex++));
+                            }
+                        } else if (inner instanceof vscode.LanguageModelDataPart && isResourceLinkMimeType(inner.mimeType)) {
+                            const stored = await resolveResourceLinkToImage(inner.data);
+                            if (stored) {
+                                if (modelSupportsVision) {
+                                    const dataPart = new vscode.LanguageModelDataPart(stored.data, stored.mimeType);
+                                    resultImages.push({ type: "input_image", image_url: createDataUrl(dataPart) });
+                                } else {
+                                    resultText.push(imageDirective(imageIndex++));
+                                }
+                            } else {
+                                const link = parseResourceLinkData(inner.data);
+                                if (link) resultText.push(`[Tool returned an unresolvable resource link: ${link.uri}]`);
+                            }
+                        }
+                    }
+
+                    const joined = resultText.join("\n").trim();
+                    const output = resultImages.length > 0
+                        ? [
+                            ...(joined ? [{ type: "input_text" as const, text: joined }] : []),
+                            ...resultImages,
+                        ]
+                        : joined;
+                    toolResults.push({ type: "function_call_output", call_id: callId, output });
+                }
+            }
+
+            const joinedText = textParts.join("").trim();
+
+            if (role === "assistant") {
+                if (joinedText) {
+                    out.push({ role: "assistant", content: [{ type: "output_text", text: joinedText }] });
+                }
+                out.push(...toolCalls);
+                continue;
+            }
+
+            if (role === "system") {
+                if (joinedText) out.push({ role: "system", content: joinedText });
+                continue;
+            }
+
+            out.push(...toolResults);
+            const userContent: ResponsesInputContent[] = [];
+            if (joinedText) userContent.push({ type: "input_text", text: joinedText });
+            for (const image of imageParts) {
+                userContent.push({ type: "input_image", image_url: createDataUrl(image) });
+            }
+            if (userContent.length > 0) out.push({ role: "user", content: userContent });
+        }
+
+        this._originalApiMessages = out;
+        return out;
+    }
+
+    /** Apply model and VS Code options to a Responses request body. */
+    prepareRequestBody(
+        rb: ResponsesRequestBody,
+        um: OpenCodeGoModelItem | undefined,
+        options?: ProvideLanguageModelChatResponseOptions
+    ): ResponsesRequestBody {
+        if (um?.temperature !== undefined && um.temperature !== null && um.supportsTemperature !== false) {
+            rb.temperature = um.temperature;
+        }
+        if (um?.top_p !== undefined && um.top_p !== null && um.supportsTemperature !== false) {
+            rb.top_p = um.top_p;
+        }
+        if (um?.max_completion_tokens !== undefined) {
+            rb.max_output_tokens = um.max_completion_tokens;
+        } else if (um?.max_tokens !== undefined) {
+            rb.max_output_tokens = um.max_tokens;
+        }
+
+        if (um?.enable_thinking === false) {
+            rb.reasoning = { effort: "none" };
+        } else {
+            const effort = um?.reasoning_effort;
+            rb.reasoning = {
+                ...(effort && effort !== "adaptive" ? { effort } : {}),
+                summary: "auto",
+            };
+            rb.include = ["reasoning.encrypted_content"];
+        }
+
+        const toolConfig = convertToolsToResponses(options);
+        const tools = [...(toolConfig.tools ?? [])];
+        if (this._hasImages) {
+            tools.push(convertOpenAIToolToResponses(ASK_IMAGE_TOOL_DEF as OpenAIFunctionToolDef));
+            if (this._localImages.length >= 2) {
+                tools.push(convertOpenAIToolToResponses(ASK_WITH_MULTI_IMAGE_TOOL_DEF as OpenAIFunctionToolDef));
+            }
+        }
+        if (tools.length > 0) rb.tools = tools;
+        if (this._hasImages) {
+            rb.tool_choice = "auto";
+        } else if (toolConfig.tool_choice) {
+            rb.tool_choice = toolConfig.tool_choice;
+        }
+
+        const reserved = new Set([
+            "model", "input", "stream", "store", "max_output_tokens", "temperature", "top_p",
+            "reasoning", "include", "tools", "tool_choice", "instructions", "text",
+        ]);
+        if (um?.extra && typeof um.extra === "object") {
+            for (const [key, value] of Object.entries(um.extra)) {
+                if (reserved.has(key)) {
+                    logger.warn("extra.conflict", { key, file: "responsesApi" });
+                } else if (value !== undefined) {
+                    rb[key] = value;
+                }
+            }
+        }
+        return rb;
+    }
+
+    private reportUsage(usageData: ResponsesUsage | undefined): void {
+        if (!usageData) return;
+        const promptTokens = usageData.input_tokens ?? 0;
+        const cacheHitTokens = usageData.input_tokens_details?.cached_tokens;
+        const usage: StreamUsage = {
+            promptTokens,
+            completionTokens: usageData.output_tokens ?? 0,
+            cacheHitTokens,
+            cacheMissTokens: cacheHitTokens === undefined ? undefined : Math.max(0, promptTokens - cacheHitTokens),
+        };
+        this._onUsage?.(usage);
+    }
+
+    private streamIndex(event: ResponsesStreamEvent): number {
+        return typeof event.output_index === "number" ? event.output_index : 0;
+    }
+
+    private startFunctionCall(event: ResponsesStreamEvent, item: ResponsesStreamItem): void {
+        const index = this.streamIndex(event);
+        if (this._completedToolCallIndices.has(index)) return;
+        const existing = this._toolCallBuffers.get(index);
+        this._toolCallBuffers.set(index, {
+            id: item.call_id ?? item.id ?? existing?.id,
+            name: item.name ?? existing?.name,
+            args: existing?.args || item.arguments || "",
+        });
+    }
+
+    private async processEvent(
+        event: ResponsesStreamEvent,
+        progress: Progress<LanguageModelResponsePart>
+    ): Promise<boolean> {
+        switch (event.type) {
+            case "response.output_text.delta":
+                if (event.delta) {
+                    this.reportEndThinking(progress);
+                    this.processTextContent(event.delta, progress);
+                    this._hasEmittedAssistantText = true;
+                }
+                return false;
+
+            case "response.reasoning_text.delta":
+            case "response.reasoning_summary.delta":
+            case "response.reasoning_summary_text.delta":
+                if (event.delta) this.bufferThinkingContent(event.delta, progress);
+                return false;
+
+            case "response.output_item.added":
+                if (event.item?.type === "function_call") this.startFunctionCall(event, event.item);
+                return false;
+
+            case "response.function_call_arguments.delta": {
+                const index = this.streamIndex(event);
+                if (this._completedToolCallIndices.has(index)) return false;
+                const buffer = this._toolCallBuffers.get(index) ?? { args: "" };
+                if (event.delta) buffer.args += event.delta;
+                this._toolCallBuffers.set(index, buffer);
+                await this.tryEmitBufferedToolCall(index, progress);
+                return false;
+            }
+
+            case "response.output_item.done":
+                if (event.item?.type === "function_call") {
+                    const index = this.streamIndex(event);
+                    if (this._completedToolCallIndices.has(index)) return false;
+                    const buffer = this._toolCallBuffers.get(index) ?? { args: "" };
+                    buffer.id = event.item.call_id ?? event.item.id ?? buffer.id;
+                    buffer.name = event.item.name ?? buffer.name;
+                    if (typeof event.item.arguments === "string") buffer.args = event.item.arguments;
+                    this._toolCallBuffers.set(index, buffer);
+                    await this.tryEmitBufferedToolCall(index, progress);
+                } else if (event.item?.type === "reasoning") {
+                    this.reportEndThinking(progress);
+                }
+                return false;
+
+            case "response.completed":
+            case "response.incomplete":
+                await this.flushToolCallBuffers(progress, true);
+                this.reportEndThinking(progress);
+                this.reportUsage(event.response?.usage);
+                return true;
+
+            case "response.failed":
+            case "error": {
+                const code = event.code ?? event.response?.error?.code;
+                const message = event.message ?? event.response?.error?.message ?? "OpenAI Responses stream failed";
+                throw new Error(code ? `${code}: ${message}` : message);
+            }
+
+            default:
+                return false;
+        }
+    }
+
+    /** Parse Responses SSE events and report VS Code response parts. */
+    async processStreamingResponse(
+        responseBody: ReadableStream<Uint8Array>,
+        progress: Progress<LanguageModelResponsePart>,
+        token: CancellationToken
+    ): Promise<void> {
+        const modelId = this._modelId;
+        logger.debug("responses.stream.start", { modelId });
+        this._resetStreamState();
+
+        const reader = responseBody.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let terminal = false;
+        let cancelDisposable: vscode.Disposable | undefined;
+        if (token.onCancellationRequested) {
+            cancelDisposable = token.onCancellationRequested(() => {
+                reader.cancel().catch(() => { });
+            });
+        }
+
+        try {
+            while (!terminal && !token.isCancellationRequested) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split("\n");
+                buffer = lines.pop() ?? "";
+
+                for (const rawLine of lines) {
+                    const line = rawLine.trimEnd();
+                    if (!line.startsWith("data:")) continue;
+                    const data = line.slice(5).trim();
+                    if (!data || data === "[DONE]") continue;
+
+                    let event: ResponsesStreamEvent;
+                    try {
+                        event = JSON.parse(data) as ResponsesStreamEvent;
+                    } catch (error) {
+                        logger.error("responses.stream.chunk.error", {
+                            modelId,
+                            error: error instanceof Error ? error.message : String(error),
+                            data,
+                        });
+                        continue;
+                    }
+                    terminal = await this.processEvent(event, progress);
+                    if (terminal) break;
+                }
+            }
+            if (!terminal) await this.flushToolCallBuffers(progress, false);
+            logger.debug("responses.stream.done", { modelId });
+        } finally {
+            cancelDisposable?.dispose();
+            reader.releaseLock();
+            this.reportEndThinking(progress);
+        }
+    }
+}

--- a/src/openai/responsesApi.ts
+++ b/src/openai/responsesApi.ts
@@ -239,7 +239,15 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
         if (um?.supportsReasoning === false) {
             // Do not send reasoning controls to models that do not expose them.
         } else if (um?.enable_thinking === false) {
-            rb.reasoning = { effort: "none" };
+            // Only send an explicit off effort when the catalog says the model
+            // accepts it. Responses-native models without a `none`/`disabled`
+            // value reject `reasoning.effort: "none"`; leave reasoning unset so
+            // the model falls back to its own default behaviour.
+            if (um.supportsDisablingReasoning !== false) {
+                rb.reasoning = { effort: "none" };
+            } else {
+                logger.warn("responses.forces-thinking", { model: um.id ?? "unknown" });
+            }
         } else {
             const effort = um?.reasoning_effort;
             rb.reasoning = {

--- a/src/openai/responsesApi.ts
+++ b/src/openai/responsesApi.ts
@@ -236,7 +236,9 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
             rb.max_output_tokens = um.max_tokens;
         }
 
-        if (um?.enable_thinking === false) {
+        if (um?.supportsReasoning === false) {
+            // Do not send reasoning controls to models that do not expose them.
+        } else if (um?.enable_thinking === false) {
             rb.reasoning = { effort: "none" };
         } else {
             const effort = um?.reasoning_effort;
@@ -437,6 +439,106 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
             cancelDisposable?.dispose();
             reader.releaseLock();
             this.reportEndThinking(progress);
+        }
+    }
+
+    /** Stream a simple text response for Git commit message generation. */
+    async *createMessage(
+        model: OpenCodeGoModelItem,
+        systemPrompt: string,
+        messages: { role: string; content: string }[],
+        baseUrl: string,
+        apiKey: string,
+        signal?: AbortSignal
+    ): AsyncGenerator<{ type: "text"; text: string }> {
+        const input: ResponsesInputItem[] = messages.map((message) => {
+            if (message.role === "assistant") {
+                return {
+                    role: "assistant" as const,
+                    content: [{ type: "output_text" as const, text: message.content }],
+                };
+            }
+            if (message.role === "system") {
+                return { role: "system" as const, content: message.content };
+            }
+            return {
+                role: "user" as const,
+                content: [{ type: "input_text" as const, text: message.content }],
+            };
+        });
+
+        let requestBody: ResponsesRequestBody = {
+            model: model.id,
+            input,
+            stream: true,
+            store: false,
+            ...(systemPrompt ? { instructions: systemPrompt } : {}),
+        };
+        requestBody = this.prepareRequestBody(requestBody, model, undefined);
+
+        const headers = CommonApi.prepareHeaders(apiKey, "openai-responses", model.headers);
+        const url = `${baseUrl.replace(/\/+$/, "")}/responses`;
+        const response = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(requestBody),
+            signal,
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(
+                `Responses API error: [${response.status}] ${response.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+            );
+        }
+        if (!response.body) {
+            throw new Error("No response body from Responses API");
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let terminal = false;
+        const cancelReader = (): void => {
+            reader.cancel().catch(() => { });
+        };
+        signal?.addEventListener("abort", cancelReader, { once: true });
+
+        try {
+            while (!terminal) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split("\n");
+                buffer = lines.pop() ?? "";
+
+                for (const rawLine of lines) {
+                    const line = rawLine.trimEnd();
+                    if (!line.startsWith("data:")) continue;
+                    const data = line.slice(5).trim();
+                    if (!data || data === "[DONE]") continue;
+
+                    let event: ResponsesStreamEvent;
+                    try {
+                        event = JSON.parse(data) as ResponsesStreamEvent;
+                    } catch {
+                        continue;
+                    }
+                    if (event.type === "response.output_text.delta" && event.delta) {
+                        yield { type: "text", text: event.delta };
+                    } else if (event.type === "response.completed" || event.type === "response.incomplete") {
+                        terminal = true;
+                        break;
+                    } else if (event.type === "response.failed" || event.type === "error") {
+                        const code = event.code ?? event.response?.error?.code;
+                        const message = event.message ?? event.response?.error?.message ?? "OpenAI Responses stream failed";
+                        throw new Error(code ? `${code}: ${message}` : message);
+                    }
+                }
+            }
+        } finally {
+            signal?.removeEventListener("abort", cancelReader);
+            reader.releaseLock();
         }
     }
 }

--- a/src/openai/responsesApi.ts
+++ b/src/openai/responsesApi.ts
@@ -25,7 +25,14 @@ import {
 import { logger } from "../logger";
 import type { StoredImage } from "../vision/types";
 import { ASK_IMAGE_TOOL_DEF, ASK_WITH_MULTI_IMAGE_TOOL_DEF } from "../vision/types";
+import { parseVisionToolHistoryPart } from "../vision/historyPart";
+import { toResponsesVisionToolItems } from "../vision/historyCodec";
 import type { OpenAIFunctionToolDef } from "./openaiTypes";
+import {
+    createResponsesReasoningPart,
+    normalizeResponsesReasoningItem,
+    parseResponsesReasoningPart,
+} from "./responsesState";
 import type {
     ResponsesFunctionCallItem,
     ResponsesFunctionCallOutputItem,
@@ -43,9 +50,17 @@ const imageDirective = (imageIndex: number): string =>
 /** OpenAI Responses protocol adapter. */
 export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequestBody> {
     private _hasImages = false;
+    private _capturedReasoningItems: ResponsesInputItem[] = [];
 
     constructor(modelId: string) {
         super(modelId);
+    }
+
+    /** Return and clear reasoning items captured in the latest streaming round. */
+    takeCapturedReasoningItems(): ResponsesInputItem[] {
+        const items = this._capturedReasoningItems;
+        this._capturedReasoningItems = [];
+        return items;
     }
 
     /** Convert VS Code request messages into Responses input items. */
@@ -91,9 +106,16 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
             const imageParts: vscode.LanguageModelDataPart[] = [];
             const toolCalls: ResponsesFunctionCallItem[] = [];
             const toolResults: ResponsesFunctionCallOutputItem[] = [];
+            const internalItems: ResponsesInputItem[] = [];
 
             for (const part of message.content ?? []) {
-                if (part instanceof vscode.LanguageModelTextPart) {
+                const reasoningItem = parseResponsesReasoningPart(part);
+                const visionHistory = parseVisionToolHistoryPart(part);
+                if (reasoningItem) {
+                    internalItems.push(reasoningItem);
+                } else if (visionHistory) {
+                    internalItems.push(...toResponsesVisionToolItems(visionHistory));
+                } else if (part instanceof vscode.LanguageModelTextPart) {
                     if (modelSupportsVision) {
                         textParts.push(part.value);
                     } else {
@@ -170,6 +192,7 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
             const joinedText = textParts.join("").trim();
 
             if (role === "assistant") {
+                out.push(...internalItems);
                 if (joinedText) {
                     out.push({ role: "assistant", content: [{ type: "output_text", text: joinedText }] });
                 }
@@ -327,6 +350,13 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
                     this._toolCallBuffers.set(index, buffer);
                     await this.tryEmitBufferedToolCall(index, progress);
                 } else if (event.item?.type === "reasoning") {
+                    const item = normalizeResponsesReasoningItem(event.item);
+                    if (item) {
+                        this._capturedReasoningItems.push(item);
+                        progress.report(
+                            createResponsesReasoningPart(item) as unknown as LanguageModelResponsePart
+                        );
+                    }
                     this.reportEndThinking(progress);
                 }
                 return false;
@@ -359,6 +389,7 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
         const modelId = this._modelId;
         logger.debug("responses.stream.start", { modelId });
         this._resetStreamState();
+        this._capturedReasoningItems = [];
 
         const reader = responseBody.getReader();
         const decoder = new TextDecoder();

--- a/src/openai/responsesState.ts
+++ b/src/openai/responsesState.ts
@@ -1,0 +1,60 @@
+import * as vscode from "vscode";
+import type { ResponsesReasoningItem, ResponsesStreamItem } from "./responsesTypes";
+
+/** Hidden MIME used to replay stateless Responses reasoning items. */
+export const RESPONSES_REASONING_MIME = "application/vnd.opencodego.responses-reasoning+json";
+
+interface ResponsesReasoningPayload {
+    version: 1;
+    item: ResponsesReasoningItem;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validate a streamed reasoning item for stateless replay. */
+export function normalizeResponsesReasoningItem(item: ResponsesStreamItem): ResponsesReasoningItem | null {
+    if (
+        item.type !== "reasoning" ||
+        typeof item.id !== "string" ||
+        item.id.length === 0 ||
+        typeof item.encrypted_content !== "string" ||
+        !Array.isArray(item.summary)
+    ) {
+        return null;
+    }
+    const summary = item.summary.filter(
+        (part): part is { type: "summary_text"; text: string } =>
+            part?.type === "summary_text" && typeof part.text === "string"
+    );
+    return {
+        type: "reasoning",
+        id: item.id,
+        summary,
+        encrypted_content: item.encrypted_content,
+    };
+}
+
+/** Serialize a validated reasoning item into a hidden response part. */
+export function createResponsesReasoningPart(item: ResponsesReasoningItem): vscode.LanguageModelDataPart {
+    const payload: ResponsesReasoningPayload = { version: 1, item };
+    return new vscode.LanguageModelDataPart(
+        new TextEncoder().encode(JSON.stringify(payload)),
+        RESPONSES_REASONING_MIME
+    );
+}
+
+/** Parse a hidden reasoning part carried back by VS Code. */
+export function parseResponsesReasoningPart(part: unknown): ResponsesReasoningItem | null {
+    if (!(part instanceof vscode.LanguageModelDataPart) || part.mimeType !== RESPONSES_REASONING_MIME) {
+        return null;
+    }
+    try {
+        const payload: unknown = JSON.parse(new TextDecoder().decode(part.data));
+        if (!isRecord(payload) || payload.version !== 1 || !isRecord(payload.item)) return null;
+        return normalizeResponsesReasoningItem(payload.item as ResponsesStreamItem);
+    } catch {
+        return null;
+    }
+}

--- a/src/openai/responsesTypes.ts
+++ b/src/openai/responsesTypes.ts
@@ -1,0 +1,122 @@
+/** OpenAI Responses API request and streaming types used by the adapter. */
+
+export interface ResponsesInputText {
+    type: "input_text";
+    text: string;
+}
+
+export interface ResponsesInputImage {
+    type: "input_image";
+    image_url: string;
+}
+
+export type ResponsesInputContent = ResponsesInputText | ResponsesInputImage;
+
+export interface ResponsesOutputText {
+    type: "output_text";
+    text: string;
+}
+
+export interface ResponsesReasoningSummaryText {
+    type: "summary_text";
+    text: string;
+}
+
+export interface ResponsesReasoningItem {
+    type: "reasoning";
+    id?: string;
+    summary: ResponsesReasoningSummaryText[];
+    encrypted_content?: string | null;
+}
+
+export interface ResponsesFunctionCallItem {
+    type: "function_call";
+    id?: string;
+    call_id: string;
+    name: string;
+    arguments: string;
+}
+
+export interface ResponsesFunctionCallOutputItem {
+    type: "function_call_output";
+    call_id: string;
+    output: string | ResponsesInputContent[];
+}
+
+export type ResponsesInputItem =
+    | { role: "system"; content: string }
+    | { role: "user"; content: ResponsesInputContent[] }
+    | { role: "assistant"; content: ResponsesOutputText[] }
+    | ResponsesReasoningItem
+    | ResponsesFunctionCallItem
+    | ResponsesFunctionCallOutputItem;
+
+export interface ResponsesFunctionToolDef {
+    type: "function";
+    name: string;
+    description?: string;
+    parameters: object;
+    strict: boolean;
+}
+
+export interface ResponsesRequestBody {
+    model: string;
+    input: ResponsesInputItem[];
+    stream: true;
+    store?: boolean;
+    max_output_tokens?: number;
+    temperature?: number;
+    top_p?: number;
+    reasoning?: {
+        effort?: string;
+        summary?: "auto" | "concise" | "detailed";
+    };
+    include?: string[];
+    tools?: ResponsesFunctionToolDef[];
+    tool_choice?: string | Record<string, unknown>;
+    instructions?: string;
+    text?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+export interface ResponsesUsage {
+    input_tokens?: number;
+    output_tokens?: number;
+    input_tokens_details?: {
+        cached_tokens?: number;
+    };
+    output_tokens_details?: {
+        reasoning_tokens?: number;
+    };
+}
+
+export interface ResponsesStreamItem {
+    type?: string;
+    id?: string;
+    call_id?: string;
+    name?: string;
+    arguments?: string;
+    summary?: ResponsesReasoningSummaryText[];
+    encrypted_content?: string | null;
+}
+
+export interface ResponsesStreamEvent {
+    type: string;
+    sequence_number?: number;
+    output_index?: number;
+    content_index?: number;
+    summary_index?: number;
+    item_id?: string;
+    delta?: string;
+    text?: string;
+    item?: ResponsesStreamItem;
+    code?: string;
+    message?: string;
+    response?: {
+        id?: string;
+        status?: string;
+        usage?: ResponsesUsage;
+        incomplete_details?: { reason?: string } | null;
+        error?: { code?: string; message?: string } | null;
+    };
+}

--- a/src/provideToken.ts
+++ b/src/provideToken.ts
@@ -3,6 +3,8 @@ import { LanguageModelChatRequestMessage, LanguageModelChatTool } from "vscode";
 import { tokenizerManager } from "./tokenizer/tokenizerManager";
 import { getImageDimensions } from "./tokenizer/imageUtils";
 import { createDataUrl } from "./utils";
+import { VISION_TOOL_HISTORY_MIME } from "./vision/historyCodec";
+import { RESPONSES_REASONING_MIME } from "./openai/responsesState";
 
 export const BaseTokensPerMessage = 3;
 export const BaseTokensPerName = 1;
@@ -20,7 +22,10 @@ export async function countMessageTokens(
             if (part instanceof vscode.LanguageModelTextPart) {
                 totalTokens += await textTokenLength(part.value);
             } else if (part instanceof vscode.LanguageModelDataPart) {
-                if (part.mimeType.startsWith("image/")) {
+                if (part.mimeType === VISION_TOOL_HISTORY_MIME || part.mimeType === RESPONSES_REASONING_MIME) {
+                    // These private parts are protocol replay state, not user-visible
+                    // binary input. API-reported usage remains authoritative.
+                } else if (part.mimeType.startsWith("image/")) {
                     totalTokens += calculateImageTokenCost(createDataUrl(part));
                 } else if (part.mimeType === "cache_control") {
                     /* ignore */

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -12,7 +12,7 @@ import {
 
 import * as path from "path";
 
-import type { ModelPreset, OpenCodeGoModelItem } from "./types";
+import type { ApiMode, ModelPreset, OpenCodeGoModelItem } from "./types";
 
 import { createRetryConfig, executeWithRetry, convertToolsToOpenAI } from "./utils";
 import { getCatalogProviderBaseUrl } from "./modelsDev";
@@ -23,6 +23,8 @@ import { l10nFormat } from "./localize";
 import { countMessageTokens, textTokenLength } from "./provideToken";
 import { updateContextStatusBar, recordUsage, updateCumulativeTooltip, updateStatusBarWithApiPrompt } from "./statusBar";
 import { OpenaiApi } from "./openai/openaiApi";
+import { ResponsesApi } from "./openai/responsesApi";
+import type { ResponsesRequestBody } from "./openai/responsesTypes";
 import { AnthropicApi } from "./anthropic/anthropicApi";
 import type { AnthropicRequestBody } from "./anthropic/anthropicTypes";
 import { CommonApi, type StreamUsage } from "./commonApi";
@@ -396,6 +398,73 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     token: token,
                     options: options,
                 });
+            } else if (apiMode === "openai-responses") {
+                // OpenAI Responses API mode
+                const responsesApi = new ResponsesApi(model.id);
+                responsesApi.onUsage = (usage) => {
+                    usageReportedDuringStream = true;
+                    reportNativeUsage(usage, progress);
+                    if (enableThirdPartyIndicator) {
+                        recordUsage(usage);
+                        updateCumulativeTooltip(this.statusBarItem);
+                        updateStatusBarWithApiPrompt(this.statusBarItem);
+                    }
+                };
+                const responsesInput = await responsesApi.convertMessages(messages, modelConfig);
+
+                let requestBody: ResponsesRequestBody = {
+                    model: um?.id ?? model.id,
+                    input: responsesInput,
+                    stream: true,
+                    store: false,
+                };
+                requestBody = responsesApi.prepareRequestBody(requestBody, um, options);
+
+                const url = `${BASE_URL.replace(/\/+$/, "")}/responses`;
+                logger.debug("request.body", { url, requestBody });
+                const response = await executeWithRetry(async () => {
+                    const res = await dispatchFetch(url, {
+                        method: "POST",
+                        headers: requestHeaders,
+                        body: JSON.stringify(requestBody),
+                        signal: abortController.signal,
+                    });
+
+                    if (!res.ok) {
+                        const errorText = await res.text();
+                        console.error("[OpenCodeGo] Responses API error response", errorText);
+                        if (errorText.includes("image is sensitive")) {
+                            throw new Error(`IMAGE_SENSITIVE: ${errorText}`);
+                        }
+                        throw new Error(
+                            `Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+                        );
+                    }
+
+                    return res;
+                }, retryConfig);
+
+                if (!response.body) {
+                    throw new Error("No response body from Responses API");
+                }
+                await responsesApi.processStreamingResponse(response.body, trackingProgress, token);
+
+                clearTimeout(timeoutId);
+                await this._handleInterceptedToolCall({
+                    api: responsesApi,
+                    apiMode: "openai-responses",
+                    model: model,
+                    um: um,
+                    modelApiKey: modelApiKey,
+                    baseUrl: BASE_URL,
+                    dispatchFetch: dispatchFetch,
+                    requestHeaders: requestHeaders,
+                    retryConfig: retryConfig,
+                    abortController: abortController,
+                    trackingProgress: trackingProgress,
+                    token: token,
+                    options: options,
+                });
             } else {
                 // OpenAI Chat Completions API mode
                 const openaiApi = new OpenaiApi(model.id);
@@ -572,7 +641,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
      */
     private async _handleInterceptedToolCall(params: {
         api: CommonApi<any, any>;
-        apiMode: string;
+        apiMode: ApiMode;
         model: LanguageModelChatInformation;
         um: OpenCodeGoModelItem | undefined;
         modelApiKey: string;
@@ -849,6 +918,49 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
                     if (response.body) {
                         await api.processStreamingResponse(response.body, params.trackingProgress, params.token);
+                    }
+                } else if (params.apiMode === "openai-responses") {
+                    // Responses format: preserve encrypted reasoning items, then append
+                    // the intercepted function call and its local vision result.
+                    const responsesApi = api as ResponsesApi;
+                    currentMessages.push(...responsesApi.takeCapturedReasoningItems());
+                    currentMessages.push({
+                        type: "function_call" as const,
+                        call_id: intercepted.id,
+                        name: intercepted.name,
+                        arguments: JSON.stringify(intercepted.args),
+                    });
+                    currentMessages.push({
+                        type: "function_call_output" as const,
+                        call_id: intercepted.id,
+                        output: description,
+                    });
+
+                    let body: ResponsesRequestBody = {
+                        model: params.um?.id ?? params.model.id,
+                        input: currentMessages,
+                        stream: true,
+                        store: false,
+                    };
+                    body = responsesApi.prepareRequestBody(body, params.um, params.options);
+
+                    const url = `${params.baseUrl.replace(/\/+$/, "")}/responses`;
+                    const response = await executeWithRetry(async () => {
+                        const res = await params.dispatchFetch(url, {
+                            method: "POST",
+                            headers: params.requestHeaders,
+                            body: JSON.stringify(body),
+                            signal: roundAbortController.signal,
+                        });
+                        if (!res.ok) {
+                            const errorText = await res.text();
+                            throw new Error(`Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`);
+                        }
+                        return res;
+                    }, params.retryConfig);
+
+                    if (response.body) {
+                        await responsesApi.processStreamingResponse(response.body, params.trackingProgress, params.token);
                     }
                 } else {
                     // OpenAI format: append assistant tool_call + tool result

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,8 @@ export interface OpenCodeGoModelItem {
     supportsTemperature?: boolean;
     /** Whether the catalog declares reasoning support. */
     supportsReasoning?: boolean;
+    /** Whether the catalog declares an explicit off value for reasoning effort (`none`/`disabled`). Used by the OpenAI Responses adapter to avoid sending `reasoning.effort: "none"` to models that reject it. */
+    supportsDisablingReasoning?: boolean;
     /** Custom HTTP headers */
     headers?: Record<string, string>;
     /** Cost information for this model */

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface OpenCodeGoModelItem {
     thinkingMode?: "switchable" | "always" | "adaptive";
     /** Whether this model supports setting temperature/top_p. Default true. */
     supportsTemperature?: boolean;
+    /** Whether the catalog declares reasoning support. */
+    supportsReasoning?: boolean;
     /** Custom HTTP headers */
     headers?: Record<string, string>;
     /** Cost information for this model */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+/** Request protocol used by an OpenCode model. */
+export type ApiMode = "openai" | "openai-responses" | "anthropic";
+
 /**
  * A single model entry for OpenCode Go.
  */
@@ -49,7 +52,7 @@ export interface OpenCodeGoModelItem {
      */
     delay?: number;
     /** API mode (for internal use) */
-    apiMode?: string;
+    apiMode?: ApiMode;
     /** Whether this model supports switching thinking on/off ("switchable"), always has it ("always"), or only disabled/adaptive ("adaptive") */
     thinkingMode?: "switchable" | "always" | "adaptive";
     /** Whether this model supports setting temperature/top_p. Default true. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import type { OpenCodeGoModelItem, RetryConfig } from "./types";
 import type { StoredImage } from "./vision/types";
 import { OpenAIFunctionToolDef } from "./openai/openaiTypes";
+import type { ResponsesFunctionToolDef } from "./openai/responsesTypes";
 import { CancellationToken } from "vscode";
 
 const RETRY_MAX_ATTEMPTS = 3;
@@ -134,6 +135,30 @@ export function convertToolsToOpenAI(
     }
 
     return { tools, tool_choice: toolChoice };
+}
+
+/** Convert an OpenAI Chat function definition to the flat Responses format. */
+export function convertOpenAIToolToResponses(tool: OpenAIFunctionToolDef): ResponsesFunctionToolDef {
+    return {
+        type: "function",
+        name: tool.function.name,
+        description: tool.function.description,
+        parameters: tool.function.parameters ?? { type: "object", properties: {} },
+        // VS Code tool schemas are not guaranteed to satisfy OpenAI strict-mode
+        // requirements (all properties required, additionalProperties=false).
+        strict: false,
+    };
+}
+
+/** Convert VS Code tool definitions to the flat OpenAI Responses format. */
+export function convertToolsToResponses(
+    options?: vscode.ProvideLanguageModelChatResponseOptions
+): { tools?: ResponsesFunctionToolDef[]; tool_choice?: string } {
+    const chatTools = convertToolsToOpenAI(options);
+    return {
+        tools: chatTools.tools?.map(convertOpenAIToolToResponses),
+        tool_choice: chatTools.tool_choice,
+    };
 }
 
 /**

--- a/src/vision/historyCodec.ts
+++ b/src/vision/historyCodec.ts
@@ -1,5 +1,6 @@
 import type { AnthropicMessage } from "../anthropic/anthropicTypes";
 import type { OpenAIChatMessage } from "../openai/openaiTypes";
+import type { ResponsesInputItem } from "../openai/responsesTypes";
 import { ASK_IMAGE_TOOL_NAME, ASK_WITH_MULTI_IMAGE_TOOL_NAME } from "./types";
 
 /**
@@ -119,6 +120,23 @@ export function toOpenAIVisionToolMessages(entry: VisionToolHistoryEntry): OpenA
             role: "tool",
             tool_call_id: entry.id,
             content: entry.result,
+        },
+    ];
+}
+
+/** Rebuild the standard Responses function call + output pair. */
+export function toResponsesVisionToolItems(entry: VisionToolHistoryEntry): ResponsesInputItem[] {
+    return [
+        {
+            type: "function_call",
+            call_id: entry.id,
+            name: entry.name,
+            arguments: JSON.stringify(entry.args),
+        },
+        {
+            type: "function_call_output",
+            call_id: entry.id,
+            output: entry.result,
         },
     ];
 }


### PR DESCRIPTION
## Summary

- Resolve each model's API protocol from its models.dev adapter metadata instead of assuming Chat Completions.
- Add a dedicated OpenAI Responses API adapter with typed input items, images, function tools, reasoning, usage, and SSE handling.
- Route Responses models through `/responses` in both Copilot Chat and Git commit message generation.
- Preserve encrypted reasoning items for stateless `store: false` multi-turn requests.
- Support intercepted vision tool calls across multiple Responses API rounds.
- Respect catalog-provided reasoning capabilities and avoid sending `reasoning.effort: "none"` to models that do not support it.
- Keep the existing OpenAI-compatible Chat Completions and Anthropic Messages paths unchanged.

## Background

As reported in #104, models using the `@ai-sdk/openai` adapter were still being sent to `/chat/completions`. This can fail for Responses-native models such as Grok 4.5 and newly added models that do not provide a compatible Chat Completions endpoint.

The models.dev catalog already exposes the required adapter through the model-level `provider.npm` field, with the provider-level `npm` value used as a fallback. This PR uses that metadata as the primary protocol source:

| models.dev adapter | API mode | Endpoint |
| --- | --- | --- |
| `@ai-sdk/openai` | OpenAI Responses | `/responses` |
| `@ai-sdk/openai-compatible` | OpenAI-compatible Chat | `/chat/completions` |
| `@ai-sdk/anthropic` | Anthropic Messages | `/v1/messages` |

The previous family-based detection remains only as a compatibility fallback for incomplete or older catalog data. This follows the catalog-driven model resolution direction introduced around #70.

## Responses API support

The new adapter includes:

- VS Code message conversion to Responses typed input items
- System, user, and assistant message handling
- Native image input and image-bearing tool results
- Flat function tool definitions with `strict: false`
- `function_call` and `function_call_output` conversion
- Typed Responses SSE event parsing
- Text and reasoning summary streaming
- Function argument buffering and single-emission protection
- Input, output, and cached-token usage reporting
- Explicit failure and error event propagation
- `max_output_tokens`, sampling, reasoning, and extra parameter mapping

## Stateless reasoning and tool continuity

Requests use `store: false`.

Returned reasoning items containing `encrypted_content` are preserved in an internal VS Code data part and replayed in later requests. This allows reasoning context to survive both:

- additional vision-proxy tool rounds within the same request
- later Copilot Chat turns reconstructed from conversation history

Persisted vision tool history is also converted to the appropriate representation for all three protocols:

- OpenAI Chat: `assistant.tool_calls` + `tool`
- OpenAI Responses: `function_call` + `function_call_output`
- Anthropic: `tool_use` + `tool_result`

## Git commit generation

Git commit message generation now selects `OpenaiApi`, `ResponsesApi`, or `AnthropicApi` according to the resolved model protocol.

The Responses path uses top-level `instructions`, typed input items, `store: false`, and consumes `response.output_text.delta` events.

Reasoning is disabled for commit generation only when the catalog declares a supported `none` or `disabled` effort. Models that require reasoning are no longer sent an unsupported value.

## Validation

- TypeScript compilation passed
- API mode and reasoning capability resolution tests passed
- Responses message, image, tool, request body, SSE, usage, and encrypted reasoning replay tests passed
- Vision history conversion tests passed for all three API formats
- Anthropic tool-result merge regression test passed
- ESLint completed with 0 errors; the existing 4 unused-variable warnings remain unchanged

Closes #104