### PR TITLE
fix: avoid maximum reasoning effort by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -662,7 +662,7 @@ API 实现的抽象基类。
 
 #### `protected tryEmitBufferedToolCall(index, progress): Promise<void>`
 
-当工具调用的名称和 JSON 参数都可用时，尝试发射缓冲的工具调用。跳过 `ask_image` 和 `ask_with_multi_image` 工具（由 provider 处理）。
+当工具调用的名称和 JSON 参数都可用时，立即发射缓冲的工具调用，无需等待 SSE 终止事件；`scripts/test-eager-tool-streaming.mjs` 使用保持打开的可控流验证 OpenAI Chat 与 Responses 两种协议都会在终止前上报 `read_file`，且默认 `readFileLines=0` 不改写参数。跳过 `ask_image` 和 `ask_with_multi_image` 工具（由 provider 处理）。
 
 #### `protected flushToolCallBuffers(progress, throwOnInvalid): Promise<void>`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ models.dev 目录通过 `reasoning_options` 字段提供每个模型的思考能
 
 | 目录数据 | 推导结果 | 示例 |
 | -------- | -------- | ---- |
-| `{"type":"effort","values":["high","max"]}` | `switchable`，强度档 `高/极高`（含 `禁用思考`） | deepseek-v4-*、glm-5.2、kimi-k3 (`["max"]`) |
-| `{"type":"effort","values":[...,"none",...]}` | `switchable`，`none` 映射为 `禁用思考` 档 | gpt-5.6-luna（6 档）、hy3 |
+| `{"type":"effort","values":["high","max"]}` | `switchable`，强度档含 `默认/禁用思考/高/最高`；通用默认值为 `默认`（不发送 effort） | deepseek-v4-*、glm-5.2、kimi-k3 (`["max"]`) |
+| `{"type":"effort","values":[...,"none",...]}` | `switchable`，`none` 映射为 `禁用思考` 档，另保留服务端 `默认` 档 | gpt-5.6-luna（6 档）、hy3 |
 | `{"type":"toggle"}` | `switchable`，仅 `禁用思考/思考` | qwen3.x、minimax-m3 |
 | `reasoning=true` 且 `reasoning_options=[]` | `always`（思考常开，无开关） | glm-5/5.1、kimi-k2.x、mimo 系列 |
 | `{"type":"budget_tokens","max":N}` | `thinking_budget`（OpenAI 模式请求体 `budget_tokens`） | qwen3.5/3.6 (81920)、qwen3.7/3.8 (262144) |
@@ -158,6 +158,7 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │
   ├── 2. 应用用户配置的 reasoningEffort
   │       ├── "disabled" → 关闭思考（always 模型除外）
+  │       ├── "default" → 开启思考但不发送 effort，使用服务端原生默认强度
   │       ├── "adaptive" → 开启思考，自动模式（发送 thinking: { type: "adaptive" }）
   │       ├── "enabled" → 开启思考，使用默认推理力度
   │       ├── "high"/"max" → 开启思考，指定推理力度
@@ -433,7 +434,7 @@ src/
 | `utils.ts`                            | ~490 | 工具函数（重试、角色映射、OpenAI Chat/Responses 工具格式转换等）                                                                                                                                       |
 | `statusBar.ts`                        | ~317 | 状态栏创建、更新、累计计数器、Go 用量轮询与 tooltip 区块渲染                                                                                                                                           |
 | `logger.ts`                           | ~55  | 日志输出 (LogOutputChannel)                                                                                                                                                                            |
-| `localize.ts`                         | ~109 | 中英文国际化（含 `low/medium/high/xhigh/max` 思考强度标签）                                                                                                                                            |
+| `localize.ts`                         | ~111 | 中英文国际化（含 `default/low/medium/high/xhigh/max` 思考强度标签）                                                                                                                                    |
 | `versionManager.ts`                   | ~35  | 扩展版本信息（使用正确扩展 ID `OnesoftQwQ.opencode-go-copilot-provider`）                                                                                                                              |
 | `openai/openaiApi.ts`                 | ~613 | OpenAI 格式 API 实现 (消息转换/请求构建/流式处理/图片代理)                                                                                                                                             |
 | `openai/openaiTypes.ts`               | ~75  | OpenAI 类型定义                                                                                                                                                                                        |
@@ -544,11 +545,15 @@ src/
 
 #### `buildCatalogModelInfo(providerId, modelId): LanguageModelChatInformation`
 
-构建模型选择器条目。Zen 模型名前缀 `[Zen]`，deprecated 模型前缀 `[Depr]`。推理强度枚举由 `buildReasoningEnum()` 生成：`disabled` 档在前、`none`/`disabled` effort 值归一为 `禁用思考` 档（已由 `resolveFromCatalog` 过滤，避免重复档）；`defaultReasoningEffort` 不在枚举内时回退到最高档（如 adaptive 模型的 `enabled` → `adaptive`）。当模型为 Responses 原生协议且未声明关闭档位（`supportsDisablingReasoning=false`）时不注入 `disabled` 档，避免用户选择无效的禁用项。
+构建模型选择器条目。Zen 模型名前缀 `[Zen]`，deprecated 模型前缀 `[Depr]`。推理强度枚举由 `buildReasoningEnum()` 生成：effort 型模型先注入 `default`（服务端原生默认）档，再按协议能力注入 `disabled`，最后追加目录声明的真实强度；`none`/`disabled` effort 值归一为 `禁用思考` 档（已由 `resolveFromCatalog` 过滤，避免重复档）。`defaultReasoningEffort` 不在枚举内时回退到末档（如 adaptive 模型的 `enabled` → `adaptive`）。当模型为 Responses 原生协议且未声明关闭档位（`supportsDisablingReasoning=false`）时不注入 `disabled` 档，避免用户选择无效的禁用项；`default` 始终可选。GLM-5.2 通过覆盖表继续以 `high` 为选择器默认值。
 
 #### `getCatalogModelConfig(modelId): OpenCodeGoModelItem`
 
-构建请求配置（provider.ts 与 Git 提交生成共用）。含 `baseUrl`（取自服务商 `api` 字段）、`thinking_budget`（`budget_tokens` 的 max）、`reasoning_effort`（仅真实强度档，`enabled`/`adaptive` 不发送）、`extra`（仅覆盖表）。
+构建请求配置（provider.ts 与 Git 提交生成共用）。含 `baseUrl`（取自服务商 `api` 字段）、`thinking_budget`（`budget_tokens` 的 max）、`reasoning_effort`（仅真实强度档；`default`/`enabled`/`adaptive` 不发送）、`extra`（仅覆盖表）。用户在选择器中显式选择 `default` 时，provider 还会清除覆盖表可能预设的 effort，使请求真正回到服务端默认。
+
+#### `applyReasoningEffortSelection(config, effort): void`
+
+将模型选择器的推理档应用到已解析请求配置：`disabled` 在非 always 模型上关闭思考，`default` 开启思考并清除预设 effort，`enabled` 保留基础配置，其余真实档位直接写入 `reasoning_effort`。provider 通过此纯函数统一处理选择器值，测试可直接验证 GLM-5.2 从 `high` 切换到 `default` 后确实省略 effort。
 
 ### 4.3b `src/modelOverrides.ts`
 
@@ -770,7 +775,7 @@ API 实现的抽象基类。
 
 #### `inferThinkingMode(entry) / inferSupportsDisablingReasoning(entry) / inferReasoningEfforts(entry) / inferDefaultReasoningEffort(entry) / inferVision(entry) / inferThinkingBudget(entry)`
 
-从目录条目推断：思考模式（`reasoning_options` 非空 → switchable，空但 `reasoning=true` → always；与 Chat/Anthropic 协议关闭思考的方式 `thinking` 标志解耦）、思考强度列表（`effort` 类型 values）、默认强度（最高档）、视觉能力（`attachment`/`modalities`）、思考预算（`budget_tokens` 的 min/max）。`inferSupportsDisablingReasoning()` 判断目录是否声明 `none`/`disabled` effort 档（或 toggle 型开关），**仅**由 Responses 协议适配器用于决定是否发送 `reasoning.effort="none"`：未声明关闭档位的 Responses 模型不发该值，避免端点拒绝；Chat/Anthropic 协议不受影响。
+从目录条目推断：思考模式（`reasoning_options` 非空 → switchable，空但 `reasoning=true` → always；与 Chat/Anthropic 协议关闭思考的方式 `thinking` 标志解耦）、思考强度列表（`effort` 类型 values）、默认强度（effort 型返回 `default` 并省略请求 effort；无显式 effort 时返回 `enabled`）、视觉能力（`attachment`/`modalities`）、思考预算（`budget_tokens` 的 min/max）。这样 hy3、Muse 等模型不会在每次工具调用前自动使用 `high`/`xhigh`；需要历史默认的模型可由 `MODEL_OVERRIDES` 指定真实档位（当前 GLM-5.2 为 `high`）。`inferSupportsDisablingReasoning()` 判断目录是否声明 `none`/`disabled` effort 档（或 toggle 型开关），**仅**由 Responses 协议适配器用于决定是否发送 `reasoning.effort="none"`：未声明关闭档位的 Responses 模型不发该值，避免端点拒绝；Chat/Anthropic 协议不受影响。`scripts/test-api-mode.mjs` 同时验证 hy3/Muse 的 `default` 枚举与空请求 effort、GLM 覆盖兼容；`scripts/test-eager-tool-streaming.mjs` 验证两种 OpenAI 协议的默认/显式 effort 请求体。
 
 #### `clearModelsDevCache(): void`
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Available in `settings.json`:
 | `opencodego.visionProxyThinking` | `false` | Enable thinking/reasoning in the vision proxy model when answering image queries. |
 
 > [!NOTE]
-> Models with switchable thinking (e.g., DeepSeek, Qwen) provide reasoning effort levels such as `Disabled`/`High`/`Maximum`.
+> Models with switchable thinking (e.g., DeepSeek, Qwen) provide reasoning effort levels such as `Default`/`Disabled`/`High`/`Maximum`. Effort-based models default to `Default`, which lets the provider choose its native reasoning level instead of forcing the highest advertised tier.
 
 ### Build
 
@@ -200,7 +200,7 @@ MIT License. This project references code from [oai-compatible-copilot](https://
 | `opencodego.visionProxyThinking` | `false` | 在视觉代理模型回答图片查询时启用思考/推理功能。 |
 
 > [!NOTE]
-> 支持切换思考模式的模型（如 DeepSeek、Qwen）提供`禁用思考`/`高`/`极高`等推理强度选项。
+> 支持切换思考模式的模型（如 DeepSeek、Qwen）提供`默认`/`禁用思考`/`高`/`最高`等推理强度选项。effort 型模型默认使用`默认`，由服务端决定原生推理强度，而不是自动强制最高档。
 
 ### 编译
 

--- a/package.json
+++ b/package.json
@@ -413,9 +413,10 @@
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
-		"test": "npm run compile && node scripts/test-api-mode.mjs && node scripts/test-responses-api.mjs && node scripts/test-vision-history.mjs && node scripts/test-anthropic-tool-result-merge.mjs",
+		"test": "npm run compile && node scripts/test-api-mode.mjs && node scripts/test-responses-api.mjs && node scripts/test-eager-tool-streaming.mjs && node scripts/test-vision-history.mjs && node scripts/test-anthropic-tool-result-merge.mjs",
 		"test:api-mode": "npm run compile && node scripts/test-api-mode.mjs",
 		"test:responses-api": "npm run compile && node scripts/test-responses-api.mjs",
+		"test:eager-tools": "npm run compile && node scripts/test-eager-tool-streaming.mjs",
 		"test:vision-history": "npm run compile && node scripts/test-vision-history.mjs",
 		"lint": "eslint",
 		"watch": "tsc -watch -p ./",

--- a/scripts/test-api-mode.mjs
+++ b/scripts/test-api-mode.mjs
@@ -4,8 +4,10 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const Module = require("node:module");
 const originalLoad = Module._load;
+const originalFetch = globalThis.fetch;
 
 const vscodeShim = {
+    env: { language: "en" },
     workspace: {
         getConfiguration: () => ({ get: (_key, fallback) => fallback }),
     },
@@ -28,7 +30,63 @@ Module._load = function (request, parent, isMain) {
 };
 
 try {
-    const { deduceApiModeFromCatalog, inferThinkingMode, inferSupportsDisablingReasoning } = require("../out/modelsDev.js");
+    const { logger } = require("../out/logger.js");
+    logger.init();
+    const {
+        deduceApiModeFromCatalog,
+        ensureModelsDevLoaded,
+        inferDefaultReasoningEffort,
+        inferThinkingMode,
+        inferSupportsDisablingReasoning,
+    } = require("../out/modelsDev.js");
+
+    globalThis.fetch = async () => new Response(JSON.stringify({
+        models: {},
+        providers: {
+            "opencode-go": {
+                id: "opencode-go",
+                npm: "@ai-sdk/openai-compatible",
+                api: "https://example.test/zen/go/v1",
+                models: {
+                    hy3: {
+                        id: "hy3",
+                        name: "Hy3",
+                        reasoning: true,
+                        reasoning_options: [{ type: "effort", values: ["none", "low", "high"] }],
+                        tool_call: true,
+                        temperature: true,
+                        limit: { context: 256000, output: 64000 },
+                    },
+                    "muse-spark-1.2-contributor": {
+                        id: "muse-spark-1.2-contributor",
+                        name: "Muse Spark 1.2 Contributor",
+                        reasoning: true,
+                        reasoning_options: [{ type: "effort", values: ["minimal", "low", "medium", "high", "xhigh"] }],
+                        tool_call: true,
+                        temperature: true,
+                        limit: { context: 1048576, output: 131072 },
+                        provider: { npm: "@ai-sdk/openai" },
+                    },
+                    "glm-5.2": {
+                        id: "glm-5.2",
+                        name: "GLM-5.2",
+                        reasoning: true,
+                        reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+                        tool_call: true,
+                        temperature: true,
+                        limit: { context: 202752, output: 131072 },
+                    },
+                },
+            },
+        },
+    }), { status: 200 });
+    await ensureModelsDevLoaded();
+
+    const {
+        applyReasoningEffortSelection,
+        buildCatalogModelInfo,
+        getCatalogModelConfig,
+    } = require("../out/catalogModels.js");
 
     assert.equal(deduceApiModeFromCatalog("gpt-5.6-luna", "@ai-sdk/openai"), "openai-responses");
     assert.equal(deduceApiModeFromCatalog("glm-5", "@ai-sdk/openai-compatible"), "openai");
@@ -84,7 +142,63 @@ try {
         reasoning_options: [],
     }), false);
 
+    // Effort variants are optional in OpenCode. The extension must defer to
+    // the provider by default instead of selecting the highest advertised tier.
+    assert.equal(inferDefaultReasoningEffort({
+        id: "hy3",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["none", "low", "high"] }],
+    }), "default");
+    assert.equal(inferDefaultReasoningEffort({
+        id: "muse-spark-1.2-contributor",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["minimal", "low", "medium", "high", "xhigh"] }],
+    }), "default");
+    assert.equal(inferDefaultReasoningEffort({
+        id: "always-thinking",
+        reasoning: true,
+        reasoning_options: [],
+    }), "enabled");
+
+    const hyInfo = buildCatalogModelInfo("opencode-go", "hy3");
+    assert.deepEqual(
+        hyInfo.configurationSchema.properties.reasoningEffort.enum,
+        ["default", "disabled", "low", "high"],
+    );
+    assert.equal(hyInfo.configurationSchema.properties.reasoningEffort.default, "default");
+    assert.equal(getCatalogModelConfig("hy3").reasoning_effort, undefined);
+
+    const museInfo = buildCatalogModelInfo("opencode-go", "muse-spark-1.2-contributor");
+    assert.deepEqual(
+        museInfo.configurationSchema.properties.reasoningEffort.enum,
+        ["default", "minimal", "low", "medium", "high", "xhigh"],
+    );
+    assert.equal(museInfo.configurationSchema.properties.reasoningEffort.default, "default");
+    assert.equal(getCatalogModelConfig("muse-spark-1.2-contributor").reasoning_effort, undefined);
+
+    // The historical GLM override remains explicit, while "default" stays
+    // available for users who want to opt back into provider behaviour.
+    const glmInfo = buildCatalogModelInfo("opencode-go", "glm-5.2");
+    assert.equal(glmInfo.configurationSchema.properties.reasoningEffort.default, "high");
+    assert.ok(glmInfo.configurationSchema.properties.reasoningEffort.enum.includes("default"));
+    const glmConfig = getCatalogModelConfig("glm-5.2");
+    assert.equal(glmConfig.reasoning_effort, "high");
+    applyReasoningEffortSelection(glmConfig, "default");
+    assert.equal(glmConfig.reasoning_effort, undefined);
+    assert.equal(glmConfig.enable_thinking, true);
+    assert.equal(glmConfig.include_reasoning_in_request, true);
+
+    const disabledHyConfig = getCatalogModelConfig("hy3");
+    applyReasoningEffortSelection(disabledHyConfig, "disabled");
+    assert.equal(disabledHyConfig.enable_thinking, false);
+    assert.equal(disabledHyConfig.include_reasoning_in_request, false);
+
+    const explicitHyConfig = getCatalogModelConfig("hy3");
+    applyReasoningEffortSelection(explicitHyConfig, "high");
+    assert.equal(explicitHyConfig.reasoning_effort, "high");
+
     console.log("api mode resolution: ok");
 } finally {
     Module._load = originalLoad;
+    globalThis.fetch = originalFetch;
 }

--- a/scripts/test-eager-tool-streaming.mjs
+++ b/scripts/test-eager-tool-streaming.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const Module = require("node:module");
+const originalLoad = Module._load;
+
+class DataPart {
+    constructor(data, mimeType) {
+        this.data = data;
+        this.mimeType = mimeType;
+    }
+}
+class TextPart {
+    constructor(value) {
+        this.value = value;
+    }
+}
+class ToolCallPart {
+    constructor(callId, name, input) {
+        this.callId = callId;
+        this.name = name;
+        this.input = input;
+    }
+}
+class ToolResultPart {
+    constructor(callId, content) {
+        this.callId = callId;
+        this.content = content;
+    }
+}
+class ThinkingPart {
+    constructor(value, id) {
+        this.value = value;
+        this.id = id;
+    }
+}
+
+const vscodeShim = {
+    LanguageModelDataPart: DataPart,
+    LanguageModelTextPart: TextPart,
+    LanguageModelToolCallPart: ToolCallPart,
+    LanguageModelToolResultPart: ToolResultPart,
+    LanguageModelThinkingPart: ThinkingPart,
+    LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+    extensions: { getExtension: () => undefined },
+    version: "test",
+    workspace: {
+        getConfiguration: () => ({ get: (_key, fallback) => fallback }),
+    },
+    window: {
+        createOutputChannel: () => ({
+            debug() {},
+            info() {},
+            warn() {},
+            error() {},
+            dispose() {},
+        }),
+    },
+};
+
+Module._load = function (request, parent, isMain) {
+    if (request === "vscode") return vscodeShim;
+    return originalLoad.call(this, request, parent, isMain);
+};
+
+const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: () => ({ dispose() {} }),
+};
+
+function createControlledSseStream() {
+    const encoder = new TextEncoder();
+    let controller;
+    const stream = new ReadableStream({
+        start(value) {
+            controller = value;
+        },
+    });
+    return {
+        stream,
+        send(payload) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+        },
+        sendDone() {
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        },
+        close() {
+            controller.close();
+        },
+    };
+}
+
+function waitForToolCall(parts, startProcessing) {
+    let resolveToolCall;
+    const toolCallPromise = new Promise((resolve) => {
+        resolveToolCall = resolve;
+    });
+    const processing = startProcessing({
+        report(part) {
+            parts.push(part);
+            if (part instanceof ToolCallPart) resolveToolCall(part);
+        },
+    });
+    return { processing, toolCallPromise };
+}
+
+async function expectBeforeTerminal(toolCallPromise, processing, terminal) {
+    let processingSettled = false;
+    processing.finally(() => {
+        processingSettled = true;
+    });
+
+    const toolCall = await Promise.race([
+        toolCallPromise,
+        new Promise((_, reject) => setTimeout(() => reject(new Error("tool call was not emitted eagerly")), 1000)),
+    ]);
+    assert.equal(processingSettled, false, "stream must still be active when the tool call is emitted");
+    assert.equal(toolCall.name, "read_file");
+    assert.deepEqual(toolCall.input, { filePath: "/workspace/a.ts" });
+    assert.equal("endLine" in toolCall.input, false, "default readFileLines=0 must not rewrite the call");
+
+    terminal();
+    await processing;
+}
+
+try {
+    const { logger } = require("../out/logger.js");
+    logger.init();
+    const { OpenaiApi } = require("../out/openai/openaiApi.js");
+    const { ResponsesApi } = require("../out/openai/responsesApi.js");
+
+    {
+        const controlled = createControlledSseStream();
+        const parts = [];
+        const { processing, toolCallPromise } = waitForToolCall(parts, (progress) =>
+            new OpenaiApi("hy3").processStreamingResponse(controlled.stream, progress, token),
+        );
+
+        controlled.send({
+            choices: [{
+                delta: {
+                    tool_calls: [{
+                        index: 0,
+                        id: "call_chat_read",
+                        type: "function",
+                        function: {
+                            name: "read_file",
+                            arguments: JSON.stringify({ filePath: "/workspace/a.ts" }),
+                        },
+                    }],
+                },
+                finish_reason: null,
+            }],
+        });
+
+        await expectBeforeTerminal(toolCallPromise, processing, () => {
+            controlled.sendDone();
+            controlled.close();
+        });
+        assert.equal(parts.filter((part) => part instanceof ToolCallPart).length, 1);
+    }
+
+    {
+        const controlled = createControlledSseStream();
+        const parts = [];
+        const { processing, toolCallPromise } = waitForToolCall(parts, (progress) =>
+            new ResponsesApi("muse-spark-1.2-contributor").processStreamingResponse(controlled.stream, progress, token),
+        );
+
+        controlled.send({
+            type: "response.output_item.added",
+            output_index: 0,
+            item: {
+                type: "function_call",
+                id: "item_responses_read",
+                call_id: "call_responses_read",
+                name: "read_file",
+                arguments: "",
+            },
+        });
+        controlled.send({
+            type: "response.function_call_arguments.delta",
+            output_index: 0,
+            item_id: "item_responses_read",
+            delta: JSON.stringify({ filePath: "/workspace/a.ts" }),
+        });
+
+        await expectBeforeTerminal(toolCallPromise, processing, () => {
+            controlled.send({
+                type: "response.completed",
+                response: { usage: { input_tokens: 1, output_tokens: 1 } },
+            });
+            controlled.close();
+        });
+        assert.equal(parts.filter((part) => part instanceof ToolCallPart).length, 1);
+    }
+
+    console.log("eager tool streaming: ok");
+} finally {
+    Module._load = originalLoad;
+}

--- a/scripts/test-eager-tool-streaming.mjs
+++ b/scripts/test-eager-tool-streaming.mjs
@@ -130,6 +130,43 @@ try {
     const { OpenaiApi } = require("../out/openai/openaiApi.js");
     const { ResponsesApi } = require("../out/openai/responsesApi.js");
 
+    const hyDefaultBody = new OpenaiApi("hy3").prepareRequestBody(
+        { model: "hy3", messages: [], stream: true },
+        { id: "hy3", owned_by: "opencode", enable_thinking: true },
+    );
+    assert.equal("reasoning_effort" in hyDefaultBody, false);
+    assert.deepEqual(hyDefaultBody.thinking, { type: "enabled" });
+
+    const hyHighBody = new OpenaiApi("hy3").prepareRequestBody(
+        { model: "hy3", messages: [], stream: true },
+        { id: "hy3", owned_by: "opencode", enable_thinking: true, reasoning_effort: "high" },
+    );
+    assert.equal(hyHighBody.reasoning_effort, "high");
+
+    const museDefaultBody = new ResponsesApi("muse-spark-1.2-contributor").prepareRequestBody(
+        { model: "muse-spark-1.2-contributor", input: [], stream: true, store: false },
+        {
+            id: "muse-spark-1.2-contributor",
+            owned_by: "opencode",
+            supportsReasoning: true,
+            enable_thinking: true,
+        },
+    );
+    assert.deepEqual(museDefaultBody.reasoning, { summary: "auto" });
+    assert.equal("effort" in museDefaultBody.reasoning, false);
+
+    const museExtraHighBody = new ResponsesApi("muse-spark-1.2-contributor").prepareRequestBody(
+        { model: "muse-spark-1.2-contributor", input: [], stream: true, store: false },
+        {
+            id: "muse-spark-1.2-contributor",
+            owned_by: "opencode",
+            supportsReasoning: true,
+            enable_thinking: true,
+            reasoning_effort: "xhigh",
+        },
+    );
+    assert.deepEqual(museExtraHighBody.reasoning, { effort: "xhigh", summary: "auto" });
+
     {
         const controlled = createControlledSseStream();
         const parts = [];

--- a/src/catalogModels.ts
+++ b/src/catalogModels.ts
@@ -187,12 +187,13 @@ function buildReasoningEnum(meta: ModelMeta): {
         meta.apiMode !== "openai-responses" || meta.supportsDisablingReasoning !== false;
     let enumValues: string[];
     if (hasEfforts) {
+        const effortValues = ["default", ...meta.supportedReasoningEfforts];
         if (meta.thinkingMode === "switchable") {
             enumValues = canShowDisabled
-                ? ["disabled", ...meta.supportedReasoningEfforts]
-                : [...meta.supportedReasoningEfforts];
+                ? ["default", "disabled", ...meta.supportedReasoningEfforts]
+                : effortValues;
         } else {
-            enumValues = [...meta.supportedReasoningEfforts];
+            enumValues = effortValues;
         }
     } else {
         if (meta.thinkingMode === "switchable") {
@@ -212,6 +213,7 @@ function buildReasoningEnum(meta: ModelMeta): {
 
     const getLabel = (e: string): string => {
         switch (e) {
+            case 'default': return l10n("Default");
             case 'disabled': return l10n("Disabled");
             case 'adaptive': return l10n("Adaptive");
             case 'enabled': return l10n("Thinking");
@@ -225,6 +227,7 @@ function buildReasoningEnum(meta: ModelMeta): {
     };
     const getDesc = (e: string): string => {
         switch (e) {
+            case 'default': return l10n("Use the model's default reasoning effort");
             case 'disabled': return l10n("Do not enable thinking");
             case 'adaptive': return l10n("Automatically decide when to think");
             case 'enabled': return l10n("Enable thinking");
@@ -374,9 +377,15 @@ export function getCatalogModelConfig(modelId: string): OpenCodeGoModelItem {
         cost: meta.cost,
     };
 
-    // Only send an explicit effort when it is a real effort value
-    // ("enabled"/"adaptive" are handled via the thinking flags instead).
-    if (meta.defaultReasoningEffort && meta.defaultReasoningEffort !== "enabled" && meta.defaultReasoningEffort !== "adaptive") {
+    // Only send an explicit effort when it is a real effort value. "default"
+    // deliberately defers to the provider; "enabled"/"adaptive" are handled
+    // via the thinking flags instead.
+    if (
+        meta.defaultReasoningEffort &&
+        meta.defaultReasoningEffort !== "default" &&
+        meta.defaultReasoningEffort !== "enabled" &&
+        meta.defaultReasoningEffort !== "adaptive"
+    ) {
         config.reasoning_effort = meta.defaultReasoningEffort;
     }
     if (meta.thinkingBudget?.max !== undefined) {
@@ -387,4 +396,31 @@ export function getCatalogModelConfig(modelId: string): OpenCodeGoModelItem {
     }
 
     return config;
+}
+
+/** Apply a reasoning-effort picker value to a resolved request config. */
+export function applyReasoningEffortSelection(
+    config: OpenCodeGoModelItem,
+    effort: string | undefined
+): void {
+    if (!effort) return;
+
+    if (effort === "disabled") {
+        if (config.thinkingMode !== "always") {
+            config.enable_thinking = false;
+            config.include_reasoning_in_request = false;
+            config.reasoning_effort = undefined;
+        }
+        return;
+    }
+
+    config.enable_thinking = true;
+    config.include_reasoning_in_request = true;
+    if (effort === "default") {
+        // Clear catalog/override defaults (for example GLM-5.2 defaults to
+        // high) when the user explicitly asks for provider-native behaviour.
+        config.reasoning_effort = undefined;
+    } else if (effort !== "enabled") {
+        config.reasoning_effort = effort;
+    }
 }

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -50,6 +50,7 @@ const zhCN: Record<string, string> = {
 		"服务端连接被关闭，生成内容过长时间过长。请重试或请求较短的内容。",
 
 	// reasoning effort labels (keys are English fallback text)
+	"Default": "默认",
 	"Disabled": "禁用思考",
 	"Adaptive": "自动",
 	"Thinking": "思考",
@@ -60,6 +61,7 @@ const zhCN: Record<string, string> = {
 	"Maximum": "最高",
 
 	// reasoning effort descriptions (keys are English fallback text)
+	"Use the model's default reasoning effort": "使用模型服务端的默认推理强度",
 	"Do not enable thinking": "不启用思考",
 	"Automatically decide when to think": "自动决定何时思考",
 	"Enable thinking": "启用思考",

--- a/src/modelsDev.ts
+++ b/src/modelsDev.ts
@@ -370,11 +370,13 @@ export function inferReasoningEfforts(entry: ModelsDevEntry): string[] | undefin
 
 /**
  * Infer the default reasoning effort from a catalog model entry.
- * Returns the last (highest) effort value, or "enabled" if no effort values.
+ * Effort-style models default to the provider's own reasoning level instead
+ * of forcing the last (highest) advertised variant. Models without explicit
+ * effort values keep the existing generic "enabled" behaviour.
  */
 export function inferDefaultReasoningEffort(entry: ModelsDevEntry): string {
     const efforts = inferReasoningEfforts(entry);
-    if (efforts && efforts.length > 0) return efforts[efforts.length - 1];
+    if (efforts && efforts.length > 0) return "default";
     return "enabled";
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -18,7 +18,12 @@ import { createRetryConfig, executeWithRetry, convertToolsToOpenAI } from "./uti
 import { getCatalogProviderBaseUrl } from "./modelsDev";
 
 import { prepareLanguageModelChatInformation } from "./provideModel";
-import { getCatalogModelConfig, resolveProviderForModelId, resolveVisionProxyModelId } from "./catalogModels";
+import {
+    applyReasoningEffortSelection,
+    getCatalogModelConfig,
+    resolveProviderForModelId,
+    resolveVisionProxyModelId,
+} from "./catalogModels";
 import { l10nFormat } from "./localize";
 import { countMessageTokens, textTokenLength } from "./provideToken";
 import { updateContextStatusBar, recordUsage, updateCumulativeTooltip, updateStatusBarWithApiPrompt } from "./statusBar";
@@ -179,25 +184,11 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
             // Apply reasoning effort from model configuration to determine thinking mode
             // - "disabled" → turn off thinking (unless model has thinkingMode="always")
+            // - "default" → enable thinking but let the provider choose its effort
             // - "enabled" → turn on thinking with default effort
             // - "high"/"max" → turn on thinking with specified effort
             if (um) {
-                const effort = getRequestedReasoningEffort(options);
-                if (effort) {
-                    if (effort === "disabled") {
-                        if (um.thinkingMode !== "always") {
-                            um.enable_thinking = false;
-                            um.include_reasoning_in_request = false;
-                            um.reasoning_effort = undefined;
-                        }
-                    } else {
-                        um.enable_thinking = true;
-                        um.include_reasoning_in_request = true;
-                        if (effort !== "enabled") {
-                            um.reasoning_effort = effort;
-                        }
-                    }
-                }
+                applyReasoningEffortSelection(um, getRequestedReasoningEffort(options));
             }
 
             // Inject temperature & top_p from model preset or custom settings


### PR DESCRIPTION
## Summary

- add a provider-default reasoning option for effort-based models
- stop automatically selecting the highest advertised reasoning tier
- preserve explicit reasoning choices and the existing GLM-5.2 `high` override
- add regression coverage for eager tool-call streaming in Chat Completions and Responses APIs

## Root cause

Each `read_file` tool call starts another model inference round after Copilot returns the file contents.

The extension previously treated the last advertised reasoning effort as the default. This caused:

- `hy3` to use `high`
- Muse Spark to use `xhigh`

The additional reasoning latency was repeated for every file read, making repository exploration appear exceptionally slow. The `read_file` implementation itself does not add a delay: tool calls are emitted as soon as their JSON arguments are complete.

## Changes

Effort-based models now expose a `Default` option that lets the provider choose its native reasoning level without sending `reasoning_effort` or `reasoning.effort`.

Explicit selections such as `low`, `high`, and `xhigh` continue to be forwarded unchanged. Disabling reasoning and always-thinking models retain their existing behavior.

The historical GLM-5.2 `high` default is preserved, while users can explicitly select `Default` to return to provider-native behavior.

## Tests

- `npm run compile`
- `npx tsc --noEmit`
- `npm test`
- controlled SSE tests confirming `read_file` is emitted before stream termination
- request-body tests for default and explicit reasoning efforts
- regression coverage for hy3, Muse Spark, disabled reasoning, and GLM-5.2

Closes #108