### PR TITLE
fix: tolerate missing MIME types and honor tool mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -856,7 +856,7 @@ API 实现的抽象基类。
 
 将 VS Code 消息角色映射为字符串角色。
 
-#### `convertToolsToOpenAI(options?): { tools?, tool_choice? }`
+#### `convertToolsToOpenAI(options?, modelId?): { tools?, tool_choice? }`
 
 将 VS Code 工具定义转换为 OpenAI 函数工具定义。
 
@@ -1680,6 +1680,12 @@ type 取值：`feat` | `fix` | `refactor` | `docs` | `chore` | `improve` 等。
 | 常量     | UPPER_SNAKE_CASE | `BASE_TOKENS_PER_MESSAGE`, `DEFAULT_CONTEXT_LENGTH` |
 | 私有属性 | `_` 前缀         | `_lastRequestTime`, `_toolCallBuffers`              |
 | 文件     | camelCase        | `provider.ts`, `commitMessageGenerator.ts`          |
+
+### Compatibility safeguards
+
+- Runtime `LanguageModelDataPart.mimeType` values are treated as unknown at the MIME boundary; missing values must not reach string methods or crash token counting.
+- Tool selection reads the official `ProvideLanguageModelChatResponseOptions.toolMode` and keeps `modelOptions.toolMode` as a legacy fallback.
+- OpenCode Zen free model IDs downgrade forced `required` tool selection to `auto` for endpoint compatibility.
 
 ### 6.7 VS Code API 使用约束
 

--- a/scripts/test-responses-api.mjs
+++ b/scripts/test-responses-api.mjs
@@ -9,7 +9,9 @@ const originalFetch = globalThis.fetch;
 class DataPart {
     constructor(data, mimeType) {
         this.data = data;
-        this.mimeType = mimeType;
+        if (mimeType !== undefined) {
+            this.mimeType = mimeType;
+        }
     }
 }
 class TextPart {
@@ -44,6 +46,7 @@ const vscodeShim = {
     LanguageModelToolResultPart: ToolResultPart,
     LanguageModelThinkingPart: ThinkingPart,
     LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+    LanguageModelChatToolMode: { Auto: 1, Required: 2 },
     extensions: { getExtension: () => undefined },
     version: "test",
     workspace: { getConfiguration: () => ({ get: (_key, fallback) => fallback }) },
@@ -78,10 +81,45 @@ const makeStream = (events) => {
 try {
     const { logger } = require("../out/logger.js");
     logger.init();
+    const { convertToolsToOpenAI, isImageMimeType } = require("../out/utils.js");
+    const { countMessageTokens } = require("../out/provideToken.js");
     const { ResponsesApi } = require("../out/openai/responsesApi.js");
     const { RESPONSES_REASONING_MIME } = require("../out/openai/responsesState.js");
 
     const api = new ResponsesApi("gpt-5.6-luna");
+    assert.equal(isImageMimeType(undefined), false);
+    assert.equal(isImageMimeType("image/png"), true);
+    assert.equal(
+        await countMessageTokens(
+            { role: 1, content: [new DataPart(new Uint8Array([1, 2]), undefined)] },
+            { includeReasoningInRequest: false },
+        ),
+        6,
+    );
+
+    const toolDefinitions = [{ name: "read_file", description: "Read a file", inputSchema: { type: "object" } }];
+    assert.equal(
+        convertToolsToOpenAI(
+            { tools: toolDefinitions, toolMode: vscodeShim.LanguageModelChatToolMode.Required },
+            "gpt-5.6-luna",
+        ).tool_choice,
+        "required",
+    );
+    assert.equal(
+        convertToolsToOpenAI(
+            { tools: toolDefinitions, toolMode: vscodeShim.LanguageModelChatToolMode.Required },
+            "ox-alpha-free",
+        ).tool_choice,
+        "auto",
+    );
+    assert.equal(
+        convertToolsToOpenAI(
+            { tools: toolDefinitions, modelOptions: { toolMode: "required" } },
+            "gpt-5.6-luna",
+        ).tool_choice,
+        "required",
+    );
+
     const messages = [
         { role: 3, content: [new TextPart("System rules")] },
         { role: 1, content: [new TextPart("Inspect this"), new DataPart(new Uint8Array([1, 2]), "image/png")] },

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -394,7 +394,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 		}
 
 		// Add tools configuration
-		const toolConfig = convertToolsToOpenAI(options);
+		const toolConfig = convertToolsToOpenAI(options, um?.id ?? this._modelId);
 		const anthropicToolList: Array<{ name: string; description?: string; input_schema?: object }> = [];
 		if (toolConfig.tools) {
 			for (const tool of toolConfig.tools) {

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -381,7 +381,7 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
         }
 
         // tools
-        const toolConfig = convertToolsToOpenAI(options);
+        const toolConfig = convertToolsToOpenAI(options, um?.id ?? this._modelId);
         const toolsList: any[] = [];
         if (toolConfig.tools) {
             toolsList.push(...toolConfig.tools);

--- a/src/openai/responsesApi.ts
+++ b/src/openai/responsesApi.ts
@@ -257,7 +257,7 @@ export class ResponsesApi extends CommonApi<ResponsesInputItem, ResponsesRequest
             rb.include = ["reasoning.encrypted_content"];
         }
 
-        const toolConfig = convertToolsToResponses(options);
+        const toolConfig = convertToolsToResponses(options, um?.id ?? this._modelId);
         const tools = [...(toolConfig.tools ?? [])];
         if (this._hasImages) {
             tools.push(convertOpenAIToolToResponses(ASK_IMAGE_TOOL_DEF as OpenAIFunctionToolDef));

--- a/src/provideToken.ts
+++ b/src/provideToken.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { LanguageModelChatRequestMessage, LanguageModelChatTool } from "vscode";
 import { tokenizerManager } from "./tokenizer/tokenizerManager";
 import { getImageDimensions } from "./tokenizer/imageUtils";
-import { createDataUrl } from "./utils";
+import { createDataUrl, isImageMimeType } from "./utils";
 import { VISION_TOOL_HISTORY_MIME } from "./vision/historyCodec";
 import { RESPONSES_REASONING_MIME } from "./openai/responsesState";
 
@@ -25,7 +25,7 @@ export async function countMessageTokens(
                 if (part.mimeType === VISION_TOOL_HISTORY_MIME || part.mimeType === RESPONSES_REASONING_MIME) {
                     // These private parts are protocol replay state, not user-visible
                     // binary input. API-reported usage remains authoritative.
-                } else if (part.mimeType.startsWith("image/")) {
+                } else if (isImageMimeType(part.mimeType)) {
                     totalTokens += calculateImageTokenCost(createDataUrl(part));
                 } else if (part.mimeType === "cache_control") {
                     /* ignore */

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -863,7 +863,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
                     // Inject tools (VS Code + ask_image + ask_with_multi_image)
                     const anthropicToolList: Array<{ name: string; description?: string; input_schema?: object }> = [];
-                    const toolConfig = convertToolsToOpenAI(params.options);
+                    const toolConfig = convertToolsToOpenAI(params.options, params.um?.id ?? params.model.id);
                     if (toolConfig.tools) {
                         for (const tool of toolConfig.tools) {
                             anthropicToolList.push({
@@ -1018,7 +1018,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
                     // Inject tools (VS Code + ask_image + ask_with_multi_image)
                     const openaiToolList: any[] = [];
-                    const toolConfig = convertToolsToOpenAI(params.options);
+                    const toolConfig = convertToolsToOpenAI(params.options, params.um?.id ?? params.model.id);
                     if (toolConfig.tools) {
                         openaiToolList.push(...toolConfig.tools);
                     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { OpenCodeGoModelItem, RetryConfig } from "./types";
 import type { StoredImage } from "./vision/types";
+import { isZenFreeModelId } from "./catalogModels";
 import { OpenAIFunctionToolDef } from "./openai/openaiTypes";
 import type { ResponsesFunctionToolDef } from "./openai/responsesTypes";
 import { CancellationToken } from "vscode";
@@ -94,11 +95,29 @@ export function mapRole(message: vscode.LanguageModelChatRequestMessage): "user"
     return "system";
 }
 
+function resolveToolMode(options?: vscode.ProvideLanguageModelChatResponseOptions): string | undefined {
+    const officialToolMode = (options as unknown as { toolMode?: unknown })?.toolMode;
+    const toolModeEnum = (vscode as typeof vscode & {
+        LanguageModelChatToolMode?: { Auto?: unknown; Required?: unknown };
+    }).LanguageModelChatToolMode;
+
+    if (officialToolMode === toolModeEnum?.Required || officialToolMode === "required") {
+        return "required";
+    }
+    if (officialToolMode === toolModeEnum?.Auto || officialToolMode === "auto") {
+        return "auto";
+    }
+
+    const legacyToolMode = (options?.modelOptions as Record<string, unknown> | undefined)?.toolMode;
+    return typeof legacyToolMode === "string" ? legacyToolMode : undefined;
+}
+
 /**
  * Convert VS Code tool definitions to OpenAI function tool definitions.
  */
 export function convertToolsToOpenAI(
-    options?: vscode.ProvideLanguageModelChatResponseOptions
+    options?: vscode.ProvideLanguageModelChatResponseOptions,
+    modelId?: string
 ): { tools?: OpenAIFunctionToolDef[]; tool_choice?: string } {
     if (!options?.tools || options.tools.length === 0) {
         return {};
@@ -122,12 +141,11 @@ export function convertToolsToOpenAI(
     });
 
     // Determine tool_choice mode
-    const toolMode = (options?.modelOptions as Record<string, unknown> | undefined)
-        ?.toolMode as string | undefined;
+    const toolMode = resolveToolMode(options);
 
     let toolChoice: string | undefined;
     if (toolMode === "required") {
-        toolChoice = "required";
+        toolChoice = modelId && isZenFreeModelId(modelId) ? "auto" : "required";
     } else if (toolMode === "none") {
         toolChoice = "none";
     } else if (toolMode === "auto") {
@@ -152,9 +170,10 @@ export function convertOpenAIToolToResponses(tool: OpenAIFunctionToolDef): Respo
 
 /** Convert VS Code tool definitions to the flat OpenAI Responses format. */
 export function convertToolsToResponses(
-    options?: vscode.ProvideLanguageModelChatResponseOptions
+    options?: vscode.ProvideLanguageModelChatResponseOptions,
+    modelId?: string
 ): { tools?: ResponsesFunctionToolDef[]; tool_choice?: string } {
-    const chatTools = convertToolsToOpenAI(options);
+    const chatTools = convertToolsToOpenAI(options, modelId);
     return {
         tools: chatTools.tools?.map(convertOpenAIToolToResponses),
         tool_choice: chatTools.tool_choice,
@@ -245,8 +264,8 @@ function isRetryableError(error: Error, retryableStatusCodes: number[]): boolean
 /**
  * Check if a mime type is an image type.
  */
-export function isImageMimeType(mimeType: string): boolean {
-    return mimeType.startsWith("image/");
+export function isImageMimeType(mimeType: unknown): boolean {
+    return typeof mimeType === "string" && mimeType.startsWith("image/");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Guard MIME type conversions when VS Code sends data parts without a MIME type, preventing `startsWith` runtime crashes.
- Honor the official `options.toolMode` field while preserving compatibility with the legacy `modelOptions.toolMode` field.
- Normalize forced `required` tool selection to `auto` for OpenCode Zen free model IDs such as `ox-alpha-free` and `big-pickle`.
- Pass the model ID through the OpenAI Chat Completions, Responses, Anthropic, and internal tool paths.
- Add regression coverage for missing MIME types, token counting, tool mode, and Ox Alpha compatibility.

## Testing

- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`