### PR TITLE
fix: resolve vision proxy model by vendor-prefixed id

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -591,7 +591,7 @@ ask_image 工具定义的 OpenAI 格式（`type: "function"`），包含 `imageI
 
 #### `callVisionModel(imageData, mimeType, visionModelId, query, token, progress?): Promise<string>`
 
-调用视觉模型回答关于图片的查询。使用 `vscode.lm.selectChatModels()` 查找模型，发送图片+查询文本，收集流式回答返回，并可通过 `progress` 实时转发 `LanguageModelTextPart`。与旧版 `describe_image` 不同，`query` 参数来自模型的 `ask_image` 工具调用，允许针对性提问（如"按钮是什么颜色？"）。支持 thinking 模式配置，通过 `opencodego.visionProxyThinking` 设置控制，开启时发送 `reasoning_effort="high"`，关闭时发送 `reasoning_effort="disabled"`。
+调用视觉模型回答关于图片的查询。先通过 `vscode.lm.selectChatModels()` 按完整模型 ID（`vendor/id`，如 `opencodego/qwen3.8-plus`）精确匹配视觉代理模型，失败时按裸 ID 后缀回退匹配（兼容 `opencodego.visionProxyModel` 配置的裸 ID，如 `qwen3.8-plus`），多提供者同名时优先本扩展的 `opencodego` 模型。发送图片+查询文本，收集流式回答返回，并可通过 `progress` 实时转发 `LanguageModelTextPart`。与旧版 `describe_image` 不同，`query` 参数来自模型的 `ask_image` 工具调用，允许针对性提问（如"按钮是什么颜色？"）。支持 thinking 模式配置，通过 `opencodego.visionProxyThinking` 设置控制，开启时发送 `reasoning_effort="high"`，关闭时发送 `reasoning_effort="disabled"`。
 
 #### `callVisionModelMulti(images, visionModelId, query, token, progress?): Promise<string>`
 

--- a/src/vision/imageProxy.ts
+++ b/src/vision/imageProxy.ts
@@ -2,6 +2,10 @@ import * as vscode from "vscode";
 import { DEFAULT_VISION_PROMPT } from "./types";
 import type { StoredImage } from "./types";
 
+// Vendor id this extension registers its chat provider under (see extension.ts
+// and the "vendor" contribution in package.json).
+const OPENCODEGO_VENDOR = "opencodego";
+
 /**
  * Build a standard set of request options for vision model calls.
  */
@@ -20,6 +24,37 @@ function buildVisionOptions(): vscode.LanguageModelChatRequestOptions {
 }
 
 /**
+ * Resolve the LanguageModelChat instance for the configured vision model ID.
+ *
+ * The `opencodego.visionProxyModel` setting stores a bare model ID (e.g.
+ * "qwen3.8-plus"), but the `id` exposed on `LanguageModelChat` by VS Code is
+ * the vendor-prefixed full identifier (e.g. "opencodego/qwen3.8-plus"), so an
+ * exact `selectChatModels({ id })` lookup never matches a bare ID. Resolution
+ * order:
+ * 1. Exact full-id match — users may configure "vendor/id" explicitly.
+ * 2. Bare-ID suffix match, preferring models registered by this extension's
+ *    own vendor to deterministically disambiguate same-named models from other
+ *    providers (e.g. "tokenrhythm/kimi-k2.6" vs "opencodego/kimi-k2.6").
+ *
+ * @returns The matched chat model, or `undefined` when nothing matches.
+ */
+async function resolveVisionModel(visionModelId: string): Promise<vscode.LanguageModelChat | undefined> {
+    const exact = await vscode.lm.selectChatModels({ id: visionModelId });
+    if (exact && exact.length > 0) {
+        return exact[0];
+    }
+    const all = await vscode.lm.selectChatModels();
+    const candidates = all.filter((model) => {
+        const bare = model.id.slice(model.id.lastIndexOf("/") + 1);
+        return bare === visionModelId;
+    });
+    if (candidates.length === 0) {
+        return undefined;
+    }
+    return candidates.find((model) => model.vendor === OPENCODEGO_VENDOR) ?? candidates[0];
+}
+
+/**
  * Send a message to a vision model, stream output via progress, and return the full text.
  * progress.onThinking is called for thinking/reasoning chunks, progress.onText for text chunks.
  */
@@ -32,11 +67,10 @@ async function sendToVisionModel(
         onText?: (text: string) => void;
     }
 ): Promise<string> {
-    const models = await vscode.lm.selectChatModels({ id: visionModelId });
-    if (!models || models.length === 0) {
+    const visionModel = await resolveVisionModel(visionModelId);
+    if (!visionModel) {
         throw new Error(`Vision model "${visionModelId}" not found. Check the opencodego.visionProxyModel setting.`);
     }
-    const visionModel = models[0];
     const response = await visionModel.sendRequest([msg], buildVisionOptions(), token);
     let result = "";
     for await (const chunk of response.stream) {


### PR DESCRIPTION
### Changes

**1. Match vision proxy model against vendor-prefixed full id**
- Rewrote the vision model lookup in `sendToVisionModel()` behind a new `resolveVisionModel()` helper: first an exact match on the full `vendor/id` identifier (supports configuring `opencodego.visionProxyModel` as `opencodego/qwen3.8-plus`), then a fallback that fetches all chat models and matches by bare ID suffix, since `LanguageModelChat.id` exposed by VS Code is vendor-prefixed while the config (and `resolveVisionProxyModelId()`) uses a bare ID.
- When several providers register same-named models (e.g. `tokenrhythm/kimi-k2.6` vs `opencodego/kimi-k2.6`), the fallback deterministically prefers this extension's own `opencodego` vendor.
- Fixes `ask_image`/`ask_with_multi_image` returning `[Image query unavailable]` with `Vision model "..." not found` when the chat model has no vision input.

**2. Docs sync**
- Updated `docs/reference.md` for the new resolution behavior.

### Files Changed

| File | Change |
| ---- | ------ |
| `src/vision/imageProxy.ts` | Add `resolveVisionModel()` with exact full-id match + bare-ID suffix fallback, prefer own vendor |
| `docs/reference.md` | Document the vision proxy model resolution order |