### PR TITLE
fix: send x-opencode-session header on inference requests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,12 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │
   ├── 9. 创建 undici fetch (自定义 bodyTimeout)
   │
+  ├── 9a. 构建请求头 → CommonApi.prepareHeaders()
+  │      └── 始终注入 x-opencode-session（OpenCode Go 自 2026-09-05 起强制要求，
+  │          服务端用于会话路由与 prompt 缓存优化）：由 deriveOpencodeSessionId()
+  │          按 模型 ID + 首条含文本用户消息 的 SHA-256 确定性派生（同会话跨轮次
+  │          稳定），无文本锚点时回退随机 UUID；视觉代理后续轮次复用同一请求头
+  │
   ├── 9b. 获取 Response body reader 后，注册取消回调
   │      └── `token.onCancellationRequested` / `signal.addEventListener("abort")`
   │      └── 调用 `reader.cancel()` 立即中断流，使 `reader.read()` 返回 `{ done: true }`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -122,6 +122,10 @@ src/
 
 创建 undici fetch 实例，设置自定义 `bodyTimeout` 防止流式响应中 TCP 空闲连接被提前关闭。回退到全局 `fetch`。
 
+#### `deriveOpencodeSessionId(modelId, messages): string`（模块级函数）
+
+派生稳定的会话 ID 用于 `x-opencode-session` 请求头。OpenCode Go 自 2026-09-05 起要求所有推理请求携带该头部（服务端用于路由与 prompt 缓存优化），缺失时请求报错。由于 VS Code 不向 Language Model Provider 暴露会话标识，该 ID 由目标模型 ID + 会话首条含文本的用户消息经 SHA-256 哈希确定性派生（格式化为标准 UUID）：同一会话每一轮都会重发相同历史，因此派生 ID 跨轮次稳定，不同会话得到不同 ID；跳过图片等二进制 DataPart。整个会话无用户文本锚点时（如纯图片请求）回退为随机 UUID。
+
 #### `provideLanguageModelChatInformation(options, _token): Promise<LanguageModelChatInformation[]>`
 
 获取可用的语言模型列表。参数类型为 `PrepareLanguageModelChatModelOptions`，委托给 `prepareLanguageModelChatInformation()`。
@@ -337,9 +341,9 @@ API 实现的抽象基类。
 
 处理普通文本内容，发射到进度报告器。
 
-#### `static prepareHeaders(apiKey, apiMode, customHeaders?): Record<string, string>`
+#### `static prepareHeaders(apiKey, apiMode, customHeaders?, sessionId?): Record<string, string>`
 
-准备 HTTP 请求头。读取 `OPENCODEGO_USER_AGENT` 环境变量覆盖 User-Agent（回退到 `VersionManager.getUserAgent()`；内部测试/应急用，非用户设置项）。Anthropic 模式使用 `x-api-key`，OpenAI 模式使用 `Bearer` 令牌。
+准备 HTTP 请求头。读取 `OPENCODEGO_USER_AGENT` 环境变量覆盖 User-Agent（回退到 `VersionManager.getUserAgent()`；内部测试/应急用，非用户设置项）。Anthropic 模式使用 `x-api-key`，OpenAI 模式使用 `Bearer` 令牌。始终注入 `x-opencode-session`：传入 `sessionId` 时使用之，否则生成随机 UUID，确保所有推理请求都携带 OpenCode Go 要求的会话标识。
 
 ---
 

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import * as vscode from "vscode";
 import {
     LanguageModelResponsePart,
@@ -428,12 +429,17 @@ export abstract class CommonApi<TMessage, TRequestBody> {
      * @param apiKey The API key to use.
      * @param apiMode The apiMode (affects header format).
      * @param customHeaders Optional custom headers from model config.
+     * @param sessionId Optional stable per-conversation session ID. OpenCode Go
+     * rejects inference requests without `x-opencode-session` since 2026-09-05
+     * (used for routing and prompt-cache optimization). When omitted, a random
+     * UUID is generated so every inference request still carries the header.
      * @returns Headers object.
      */
     public static prepareHeaders(
         apiKey: string,
         apiMode: ApiMode,
-        customHeaders?: Record<string, string>
+        customHeaders?: Record<string, string>,
+        sessionId?: string
     ): Record<string, string> {
         // Internal override for testing or contingency (e.g. if the API ever gates access by User-Agent again).
         const customUserAgent = process.env.OPENCODEGO_USER_AGENT ?? "";
@@ -444,6 +450,7 @@ export abstract class CommonApi<TMessage, TRequestBody> {
             "User-Agent": userAgent,
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate, br, zstd",
+            "x-opencode-session": sessionId?.trim() || crypto.randomUUID(),
         };
         logger.debug("prepareHeaders", {
             apiMode: apiMode,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -11,6 +11,7 @@ import {
 } from "vscode";
 
 import * as path from "path";
+import * as crypto from "crypto";
 
 import type { ApiMode, ModelPreset, OpenCodeGoModelItem } from "./types";
 
@@ -80,6 +81,51 @@ function getRequestedReasoningEffort(options: ProvideLanguageModelChatResponseOp
 
     const modelOptionsEffort = modelOptions?.reasoning_effort ?? modelOptions?.reasoningEffort;
     return typeof modelOptionsEffort === "string" ? modelOptionsEffort : undefined;
+}
+
+/**
+ * Derive a stable per-conversation session ID for the `x-opencode-session` header.
+ *
+ * OpenCode Go requires a stable per-conversation ID on every inference request
+ * (used server-side for routing and prompt-cache optimization; requests without
+ * it error since 2026-09-05). VS Code does not expose a conversation identifier
+ * to language model providers, so the ID is derived deterministically from the
+ * target model ID plus the conversation's first user message text: chat clients
+ * re-send the same history on every turn of a conversation, so the derived ID
+ * stays stable across turns while differing between conversations.
+ *
+ * @param modelId The model ID the request targets (keeps sessions distinct per model).
+ * @param messages The request messages from VS Code.
+ * @returns A UUID-formatted session ID, or a random UUID when the conversation has no user text anchor (e.g. image-only requests).
+ */
+function deriveOpencodeSessionId(
+    modelId: string,
+    messages: readonly LanguageModelChatRequestMessage[]
+): string {
+    for (const message of messages) {
+        if (message.role !== vscode.LanguageModelChatMessageRole.User) {
+            continue;
+        }
+        // Collect text parts only — binary data parts (images) are skipped so the
+        // hash stays cheap and the ID does not depend on image bytes.
+        const anchorText = message.content
+            .map((part) => {
+                if (typeof part === "string") return part;
+                if (part instanceof vscode.LanguageModelTextPart) return part.value;
+                return "";
+            })
+            .join("");
+        if (!anchorText.trim()) {
+            continue;
+        }
+        const hash = crypto.createHash("sha256");
+        hash.update(modelId);
+        hash.update(anchorText);
+        // Format the digest as a canonical UUID (8-4-4-4-12).
+        const hex = hash.digest("hex").slice(0, 32);
+        return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+    }
+    return crypto.randomUUID();
 }
 
 /**
@@ -316,7 +362,12 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             dispatchFetch = this._createFetchWithTimeout(requestTimeoutMs);
 
             // Prepare headers with custom headers if specified
-            const requestHeaders = CommonApi.prepareHeaders(modelApiKey, apiMode, um?.headers);
+            const requestHeaders = CommonApi.prepareHeaders(
+                modelApiKey,
+                apiMode,
+                um?.headers,
+                deriveOpencodeSessionId(model.id, messages)
+            );
             logger.debug("request.headers", {
                 headers: logger.sanitizeHeaders(requestHeaders as Record<string, string>),
             });


### PR DESCRIPTION
### Changes

**1. Session header on all inference requests**
- `CommonApi.prepareHeaders()` now always sets `x-opencode-session`, required by OpenCode Go since 2026-09-05 for session routing and prompt-cache optimization (requests without it error on their side).
- Call sites without a conversation identity (Git commit message generation) automatically get a random UUID per request, so every outbound inference request carries the header.

**2. Stable per-conversation session ID for chat requests**
- VS Code does not expose a conversation identifier to `LanguageModelChatProvider`, so the new `deriveOpencodeSessionId()` derives the ID deterministically from the target model ID plus the first user message text (SHA-256, formatted as a UUID).
- Chat clients re-send the same history on every turn of a conversation, so the derived ID stays stable across turns while differing between conversations; conversations with no user text anchor (e.g. image-only requests) fall back to a random UUID.
- The ID is computed once per request and reused by the vision-proxy follow-up rounds through the shared `requestHeaders`.

Closes #118.

### Files Changed

| File          | Change                                                                        |
| ------------- | ----------------------------------------------------------------------------- |
| `src/commonApi.ts` | `prepareHeaders()` adds an optional `sessionId` param and always emits `x-opencode-session` |
| `src/provider.ts`  | Adds `deriveOpencodeSessionId()` and passes it to `prepareHeaders()` for chat requests  |
| `docs/reference.md` | Documents the session ID derivation and the updated `prepareHeaders()` signature   |
| `docs/architecture.md` | Adds the request-header/session-ID step to the chat request flow diagram        |