### PR TITLE
fix: registry-based session IDs with rotation fallback for broken backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@
 
 - `request.start/end` — 请求开始/结束
 - `request.error/timeout/delay` — 请求错误/超时/延迟
-- `request.sessionRotated` — 上游提供方错误后会话 ID 轮换（warn，含 modelId）
+- `request.sessionRotated` — 上游提供方错误后会话 ID 轮换（warn，含 modelId/previousSessionId/newSessionId，视觉代理轮次额外含 visionRound）
 - `sessionRouting.reset` — 会话路由登记清空（命令触发，info，含 cleared）
 - `extension.activate` — 扩展激活（含版本号）
 - `models.loaded` — 模型加载

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@
 - `request.start/end` — 请求开始/结束
 - `request.error/timeout/delay` — 请求错误/超时/延迟
 - `request.sessionRotated` — 上游提供方错误后会话 ID 轮换（warn，含 modelId/previousSessionId/newSessionId，视觉代理轮次额外含 visionRound）
+- `sessionRouting.init` — 会话路由登记表从 globalState 恢复（info，含 restored/expired）
 - `sessionRouting.reset` — 会话路由登记清空（命令触发，info，含 cleared）
 - `extension.activate` — 扩展激活（含版本号）
 - `models.loaded` — 模型加载

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@
 
 - `request.start/end` — 请求开始/结束
 - `request.error/timeout/delay` — 请求错误/超时/延迟
+- `request.sessionRotated` — 上游提供方错误后会话 ID 轮换（warn，含 modelId）
+- `sessionRouting.reset` — 会话路由登记清空（命令触发，info，含 cleared）
 - `extension.activate` — 扩展激活（含版本号）
 - `models.loaded` — 模型加载
 - `modelsDev.fetch.*` — 目录拉取明细：`fetch.official`/`fetch.mirror`（成功，含 durationMs/bytes）、`fetch.officialFailed`/`fetch.mirrorFailed`/`fetch.timeout`/`fetch.hardcoded`（失败或回退原因）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,9 +173,19 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │
   ├── 9a. 构建请求头 → CommonApi.prepareHeaders()
   │      └── 始终注入 x-opencode-session（OpenCode Go 自 2026-09-05 起强制要求，
-  │          服务端用于会话路由与 prompt 缓存优化）：由 deriveOpencodeSessionId()
-  │          按 模型 ID + 首条含文本用户消息 的 SHA-256 确定性派生（同会话跨轮次
-  │          稳定），无文本锚点时回退随机 UUID；视觉代理后续轮次复用同一请求头
+  │          服务端用于会话亲和路由与 prompt 缓存优化）：会话 ID 由 sessionRouting.ts
+  │          登记表管理——首轮请求用随机 UUID（不立即登记，键含 assistant 输出、请求
+  │          前不存在），输出完成后按下一轮查表键 hash(模型 ID + 首条用户文本 +
+  │          首条 assistant 文本) 登记；后续轮次从重发历史中提取相同键查回同一 UUID
+  │          （同开场白的不同会话因 assistant 输出不同自然分流）；视觉代理后续轮次
+  │          复用同一请求头对象
+  │
+  ├── 9c. 上游提供方错误会话轮换（#123 兜底）:
+  │      └── _sendWithSessionFallback() 包装全部请求派发（主请求三种 apiMode +
+  │          视觉代理各轮）：失败为上游错误（5xx 或 400+api_error+upstream 签名）时
+  │          rotateSessionId() 换新会话 ID 重试一次（亲和路由可能把会话钉死在故障
+  │          后端），轮换结果持久化进登记表；用户可用 opencodego.resetSessionRouting
+  │          命令手动清空全部登记逃生
   │
   ├── 9b. 获取 Response body reader 后，注册取消回调
   │      └── `token.onCancellationRequested` / `signal.addEventListener("abort")`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,8 +177,9 @@ provideLanguageModelChatResponse(model, messages, options, progress, token)
   │          登记表管理——首轮请求用随机 UUID（不立即登记，键含 assistant 输出、请求
   │          前不存在），输出完成后按下一轮查表键 hash(模型 ID + 首条用户文本 +
   │          首条 assistant 文本) 登记；后续轮次从重发历史中提取相同键查回同一 UUID
-  │          （同开场白的不同会话因 assistant 输出不同自然分流）；视觉代理后续轮次
-  │          复用同一请求头对象
+  │          （同开场白的不同会话因 assistant 输出不同自然分流）；登记表持久化于
+  │          globalState（激活时恢复，3 天滑动 TTL，重启不丢亲和）；视觉代理后续
+  │          轮次复用同一请求头对象
   │
   ├── 9c. 上游提供方错误会话轮换（#123 兜底）:
   │      └── _sendWithSessionFallback() 包装全部请求派发（主请求三种 apiMode +

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,6 +20,7 @@ src/
 ├── modelsDev.ts                          # models.dev 目录拉取与查询
 ├── provideModel.ts                       # 模型信息提供函数（目录驱动）
 ├── provider.ts                           # Chat 模型提供商 (核心主文件)
+├── sessionRouting.ts                     # x-opencode-session 会话 ID 登记/轮换
 ├── provideToken.ts                       # Token 计数函数
 ├── statusBar.ts                          # 状态栏管理
 ├── types.ts                              # TypeScript 类型定义
@@ -122,9 +123,13 @@ src/
 
 创建 undici fetch 实例，设置自定义 `bodyTimeout` 防止流式响应中 TCP 空闲连接被提前关闭。回退到全局 `fetch`。
 
-#### `deriveOpencodeSessionId(modelId, messages): string`（模块级函数）
+#### `private async _sendWithSessionFallback(send, rotateSession): Promise<Response>`
 
-派生稳定的会话 ID 用于 `x-opencode-session` 请求头。OpenCode Go 自 2026-09-05 起要求所有推理请求携带该头部（服务端用于路由与 prompt 缓存优化），缺失时请求报错。由于 VS Code 不向 Language Model Provider 暴露会话标识，该 ID 由目标模型 ID + 会话首条含文本的用户消息经 SHA-256 哈希确定性派生（格式化为标准 UUID）：同一会话每一轮都会重发相同历史，因此派生 ID 跨轮次稳定，不同会话得到不同 ID；跳过图片等二进制 DataPart。整个会话无用户文本锚点时（如纯图片请求）回退为随机 UUID。
+发送请求，当失败为上游提供方错误（`isUpstreamProviderFailureError()` 判定，#123：会话亲和路由可能把会话钉死在故障后端）时轮换 `x-opencode-session` 并用新会话 ID 重试一次；轮换后的 ID 由 `rotateSessionId()` 持久化，后续轮次自动使用。非上游错误原样抛出。主请求（三种 apiMode）与图片代理的每一轮 fetch 均经此包装。
+
+#### 会话 ID 生命周期（由 `src/sessionRouting.ts` 提供）
+
+`provideLanguageModelChatResponse()` 中：请求前 `resolveSessionId()` 解析会话 ID（已登记会话复用，否则新随机 UUID，**不立即登记**——登记键需包含 assistant 输出，请求前尚不存在）；响应成功结束后，若本轮使用的是未登记 ID，调用 `registerSessionId()` 按下一轮查表键登记；上游错误时经 `_sendWithSessionFallback()` 轮换。视觉代理轮次复用同一请求头对象，轮换自动生效。
 
 #### `provideLanguageModelChatInformation(options, _token): Promise<LanguageModelChatInformation[]>`
 
@@ -344,6 +349,36 @@ API 实现的抽象基类。
 #### `static prepareHeaders(apiKey, apiMode, customHeaders?, sessionId?): Record<string, string>`
 
 准备 HTTP 请求头。读取 `OPENCODEGO_USER_AGENT` 环境变量覆盖 User-Agent（回退到 `VersionManager.getUserAgent()`；内部测试/应急用，非用户设置项）。Anthropic 模式使用 `x-api-key`，OpenAI 模式使用 `Bearer` 令牌。始终注入 `x-opencode-session`：传入 `sessionId` 时使用之，否则生成随机 UUID，确保所有推理请求都携带 OpenCode Go 要求的会话标识。
+
+---
+
+### 2.6b `src/sessionRouting.ts`
+
+`x-opencode-session` 会话 ID 登记表（OpenCode Go 自 2026-09-05 起强制要求该头部，服务端用于会话亲和路由与 prompt 缓存优化）。核心思路：VS Code 不向 Language Model Provider 暴露会话标识，且会话首轮请求中没有任何足以无碰撞派生 ID 的信息——因此首轮请求使用随机 UUID，输出完成后以 `hash(模型 ID + 首条用户文本 + 本轮 assistant 输出)` 为键登记；后续轮次 Copilot Chat 会原样重发完整历史，从历史中提取相同键即可查回同一 UUID（跨轮次稳定、同开场白的不同会话自然分流）。登记表为插入序 LRU，上限 512 条。
+
+#### `interface SessionResolution { sessionId: string; registered: boolean }`
+
+会话 ID 解析结果：`sessionId` 为本次请求应携带的 ID；`registered` 为 true 时表示来自登记表（无需在本轮结束后重新登记）。
+
+#### `resolveSessionId(modelId, messages): SessionResolution`
+
+解析本次请求的会话 ID。历史中已有首条用户文本 + 首条 assistant 文本（即第二轮及以后）时按锚点查表复用；否则（首轮、无用户文本）返回新随机 UUID 且 `registered: false`。
+
+#### `registerSessionId(modelId, messages, turnOutput, sessionId): void`
+
+将本轮使用的会话 ID 登记到**下一轮查表将提取的同一键**下（`hash(模型 ID + 首条用户文本 + 首条 assistant 文本)`）：本轮历史中已有 assistant 消息时（重启/LRU 逐出后的未命中重建）用历史首条 assistant 文本，真第一轮时用本轮输出（它即下一轮历史的首条 assistant）。仅在 `resolveSessionId()` 未命中（`registered === false`）的本轮成功结束后调用。
+
+#### `rotateSessionId(modelId, messages): string`
+
+生成新随机 UUID 并（当历史已可识别会话时）重新登记，用于上游提供方错误后的轮换重试——会话亲和可能把会话钉死在故障后端（#123），换 ID 即换后端。首轮（历史中尚无 assistant 输出）无法预先登记，由本轮结束后的 `registerSessionId()` 兜底。
+
+#### `resetSessionRouting(): number`
+
+清空全部登记（返回清除条数），由 `opencodego.resetSessionRouting` 命令触发，作为用户逃离劣化后端的手动逃生口。
+
+#### `isUpstreamProviderFailureError(err): boolean`
+
+从请求派发抛出的错误中判定上游提供方故障：HTTP 5xx，或 400 且响应体含 `api_error` 且含 `upstream`/`error from provider`（#123 观测到的签名）。401（鉴权）、429（限流）、内容审核拒绝等不匹配，维持既有处理路径。
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -354,11 +354,15 @@ API 实现的抽象基类。
 
 ### 2.6b `src/sessionRouting.ts`
 
-`x-opencode-session` 会话 ID 登记表（OpenCode Go 自 2026-09-05 起强制要求该头部，服务端用于会话亲和路由与 prompt 缓存优化）。核心思路：VS Code 不向 Language Model Provider 暴露会话标识，且会话首轮请求中没有任何足以无碰撞派生 ID 的信息——因此首轮请求使用随机 UUID，输出完成后以 `hash(模型 ID + 首条用户文本 + 本轮 assistant 输出)` 为键登记；后续轮次 Copilot Chat 会原样重发完整历史，从历史中提取相同键即可查回同一 UUID（跨轮次稳定、同开场白的不同会话自然分流）。登记表为插入序 LRU，上限 512 条。
+`x-opencode-session` 会话 ID 登记表（OpenCode Go 自 2026-09-05 起强制要求该头部，服务端用于会话亲和路由与 prompt 缓存优化）。核心思路：VS Code 不向 Language Model Provider 暴露会话标识，且会话首轮请求中没有任何足以无碰撞派生 ID 的信息——因此首轮请求使用随机 UUID，输出完成后以 `hash(模型 ID + 首条用户文本 + 本轮 assistant 输出)` 为键登记；后续轮次 Copilot Chat 会原样重发完整历史，从历史中提取相同键即可查回同一 UUID（跨轮次稳定、同开场白的不同会话自然分流）。登记表持久化于 `globalState`（键 `opencodego.sessionRouting.v1`，激活时经 `initSessionRouting()` 恢复），条目按最后使用时间做 3 天滑动 TTL（活跃会话持续续期，超 3 天未用的条目在加载或查表时失效），插入序 LRU，上限 512 条。
 
 #### `interface SessionResolution { sessionId: string; registered: boolean }`
 
 会话 ID 解析结果：`sessionId` 为本次请求应携带的 ID；`registered` 为 true 时表示来自登记表（无需在本轮结束后重新登记）。
+
+#### `initSessionRouting(storage): void`
+
+激活时从 `globalState` 恢复登记表（须在任何请求解析会话 ID 之前调用），超过 3 天 TTL 的条目在加载时丢弃，记录 `sessionRouting.init` 日志（含 restored/expired 数量）。之后的每次写入（登记/查表 touch/轮换/清空）自动异步持久化。
 
 #### `resolveSessionId(modelId, messages): SessionResolution`
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
 				"title": "%command.openSettings%"
 			},
 			{
+				"command": "opencodego.resetSessionRouting",
+				"category": "%commandCategory%",
+				"title": "%command.resetSessionRouting%"
+			},
+			{
 				"command": "opencodego.generateGitCommitMessage",
 				"title": "%command.generateCommit%",
 				"category": "%commandCategory%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,6 +4,7 @@
 	"command.setApiKey": "Set OpenCode Go API Key",
 	"command.getApiKey": "Get OpenCode Go API Key",
 	"command.openSettings": "Open OpenCode Go Settings",
+	"command.resetSessionRouting": "Reset Session Routing (New Session IDs)",
 	"command.generateCommit": "Generate Commit Message with OpenCodeGo",
 	"command.abortCommit": "Generate Commit Message with OpenCodeGo - Stop",
 	"command.updateModelList": "Update OpenCode Go Model List (forced)",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -4,6 +4,7 @@
 	"command.setApiKey": "设置 OpenCode Go API 密钥",
 	"command.getApiKey": "获取 OpenCode Go API 密钥",
 	"command.openSettings": "打开 OpenCode Go 设置",
+	"command.resetSessionRouting": "重置会话路由(使用新会话 ID)",
 	"command.generateCommit": "使用 OpenCodeGo 生成提交消息",
 	"command.abortCommit": "使用 OpenCodeGo 生成提交消息 - 停止",
 	"command.updateModelList": "更新 OpenCode Go 模型列表 (强制)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { VersionManager } from "./versionManager";
 import { abortCommitGeneration, generateCommitMsg } from "./gitCommit/commitMessageGenerator";
 import { TokenizerManager } from "./tokenizer/tokenizerManager";
 import { prepareLanguageModelChatInformation, resetAutoDiscoveryState } from "./provideModel";
-import { resetSessionRouting } from "./sessionRouting";
+import { initSessionRouting, resetSessionRouting } from "./sessionRouting";
 
 // ---- Walkthrough / Welcome constants ----
 
@@ -29,6 +29,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     const tokenCountStatusBarItem: vscode.StatusBarItem = initStatusBar(context, context.secrets);
     const provider = new OpenCodeGoChatModelProvider(context.secrets, tokenCountStatusBarItem);
+
+    // Restore the persisted session ID registry (3-day TTL) before any
+    // request can resolve a session ID.
+    initSessionRouting(context.globalState);
 
     // Register the OpenCode Go provider under the vendor id used in package.json
     vscode.lm.registerLanguageModelChatProvider("opencodego", provider);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { VersionManager } from "./versionManager";
 import { abortCommitGeneration, generateCommitMsg } from "./gitCommit/commitMessageGenerator";
 import { TokenizerManager } from "./tokenizer/tokenizerManager";
 import { prepareLanguageModelChatInformation, resetAutoDiscoveryState } from "./provideModel";
+import { resetSessionRouting } from "./sessionRouting";
 
 // ---- Walkthrough / Welcome constants ----
 
@@ -104,6 +105,19 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand("opencodego.openSettings", () => {
             vscode.commands.executeCommand("workbench.action.openSettings", "@ext:OnesoftQwQ.opencode-go-copilot-provider");
+        })
+    );
+
+    // Command to drop all registered session IDs so the next request of every
+    // conversation is routed as a fresh session (escape hatch when session
+    // affinity pins a conversation to a degraded backend).
+    context.subscriptions.push(
+        vscode.commands.registerCommand("opencodego.resetSessionRouting", () => {
+            const cleared = resetSessionRouting();
+            logger.info("sessionRouting.reset", { cleared });
+            vscode.window.showInformationMessage(
+                l10nFormat("Session routing reset. The next request of each conversation will use a new session ID. ({0} cleared)", cleared)
+            );
         })
     );
 

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -8,6 +8,7 @@ const zhCN: Record<string, string> = {
 
 	// extension.ts - API key prompts
 	"OpenCode Go Provider API Key": "OpenCode Go 提供商 API 密钥",
+	"Session routing reset. The next request of each conversation will use a new session ID. ({0} cleared)": "会话路由已重置,各会话的下一次请求将使用新的会话 ID。(已清除 {0} 条)",
 	"Update your OpenCode Go API key": "更新您的 OpenCode Go API 密钥",
 	"Enter your OpenCode Go API key": "输入您的 OpenCode Go API 密钥",
 	"OpenCode Go API key cleared.": "OpenCode Go API 密钥已清除。",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -241,11 +241,16 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             const apiMode = um?.apiMode || "openai";
             const baseUrl = um?.baseUrl || getCatalogProviderBaseUrl("opencode-go", "https://opencode.ai/zen/go/v1/");
 
+            // Resolve the conversation's session ID early so it can be traced
+            // in request logs (see sessionRouting.ts).
+            const session = resolveSessionId(model.id, messages);
             logger.info("request.start", {
                 modelId: model.id,
                 messageCount: messages.length,
                 apiMode,
                 baseUrl,
+                sessionId: session.sessionId,
+                sessionRegistered: session.registered,
             });
 
             // Prepare model configuration
@@ -326,11 +331,15 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             // comes from the registry when the re-sent history identifies a
             // known conversation, otherwise a fresh UUID is used and registered
             // once this turn's output is complete (see sessionRouting.ts).
-            const session = resolveSessionId(model.id, messages);
             const requestHeaders = CommonApi.prepareHeaders(modelApiKey, apiMode, um?.headers, session.sessionId);
             const rotateSession = (): void => {
+                const previousSessionId = requestHeaders["x-opencode-session"];
                 requestHeaders["x-opencode-session"] = rotateSessionId(model.id, messages);
-                logger.warn("request.sessionRotated", { modelId: model.id });
+                logger.warn("request.sessionRotated", {
+                    modelId: model.id,
+                    previousSessionId,
+                    newSessionId: requestHeaders["x-opencode-session"],
+                });
             };
             logger.debug("request.headers", {
                 headers: logger.sanitizeHeaders(requestHeaders as Record<string, string>),
@@ -729,8 +738,14 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         );
         const maxRounds = config.get<number>("opencodego.visionMaxRounds", 5);
         const rotateSession = (): void => {
+            const previousSessionId = params.requestHeaders["x-opencode-session"];
             params.requestHeaders["x-opencode-session"] = rotateSessionId(params.model.id, params.messages);
-            logger.warn("request.sessionRotated", { modelId: params.model.id, visionRound: true });
+            logger.warn("request.sessionRotated", {
+                modelId: params.model.id,
+                visionRound: true,
+                previousSessionId,
+                newSessionId: params.requestHeaders["x-opencode-session"],
+            });
         };
 
         // Accumulate messages across rounds

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -11,9 +11,15 @@ import {
 } from "vscode";
 
 import * as path from "path";
-import * as crypto from "crypto";
 
 import type { ApiMode, ModelPreset, OpenCodeGoModelItem } from "./types";
+
+import {
+    isUpstreamProviderFailureError,
+    registerSessionId,
+    resolveSessionId,
+    rotateSessionId,
+} from "./sessionRouting";
 
 import { createRetryConfig, executeWithRetry, convertToolsToOpenAI } from "./utils";
 import { getCatalogProviderBaseUrl } from "./modelsDev";
@@ -81,51 +87,6 @@ function getRequestedReasoningEffort(options: ProvideLanguageModelChatResponseOp
 
     const modelOptionsEffort = modelOptions?.reasoning_effort ?? modelOptions?.reasoningEffort;
     return typeof modelOptionsEffort === "string" ? modelOptionsEffort : undefined;
-}
-
-/**
- * Derive a stable per-conversation session ID for the `x-opencode-session` header.
- *
- * OpenCode Go requires a stable per-conversation ID on every inference request
- * (used server-side for routing and prompt-cache optimization; requests without
- * it error since 2026-09-05). VS Code does not expose a conversation identifier
- * to language model providers, so the ID is derived deterministically from the
- * target model ID plus the conversation's first user message text: chat clients
- * re-send the same history on every turn of a conversation, so the derived ID
- * stays stable across turns while differing between conversations.
- *
- * @param modelId The model ID the request targets (keeps sessions distinct per model).
- * @param messages The request messages from VS Code.
- * @returns A UUID-formatted session ID, or a random UUID when the conversation has no user text anchor (e.g. image-only requests).
- */
-function deriveOpencodeSessionId(
-    modelId: string,
-    messages: readonly LanguageModelChatRequestMessage[]
-): string {
-    for (const message of messages) {
-        if (message.role !== vscode.LanguageModelChatMessageRole.User) {
-            continue;
-        }
-        // Collect text parts only — binary data parts (images) are skipped so the
-        // hash stays cheap and the ID does not depend on image bytes.
-        const anchorText = message.content
-            .map((part) => {
-                if (typeof part === "string") return part;
-                if (part instanceof vscode.LanguageModelTextPart) return part.value;
-                return "";
-            })
-            .join("");
-        if (!anchorText.trim()) {
-            continue;
-        }
-        const hash = crypto.createHash("sha256");
-        hash.update(modelId);
-        hash.update(anchorText);
-        // Format the digest as a canonical UUID (8-4-4-4-12).
-        const hex = hash.digest("hex").slice(0, 32);
-        return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
-    }
-    return crypto.randomUUID();
 }
 
 /**
@@ -361,13 +322,16 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             // Create undici fetch with custom bodyTimeout (extends TCP idle timeout during streaming)
             dispatchFetch = this._createFetchWithTimeout(requestTimeoutMs);
 
-            // Prepare headers with custom headers if specified
-            const requestHeaders = CommonApi.prepareHeaders(
-                modelApiKey,
-                apiMode,
-                um?.headers,
-                deriveOpencodeSessionId(model.id, messages)
-            );
+            // Prepare headers with custom headers if specified. The session ID
+            // comes from the registry when the re-sent history identifies a
+            // known conversation, otherwise a fresh UUID is used and registered
+            // once this turn's output is complete (see sessionRouting.ts).
+            const session = resolveSessionId(model.id, messages);
+            const requestHeaders = CommonApi.prepareHeaders(modelApiKey, apiMode, um?.headers, session.sessionId);
+            const rotateSession = (): void => {
+                requestHeaders["x-opencode-session"] = rotateSessionId(model.id, messages);
+                logger.warn("request.sessionRotated", { modelId: model.id });
+            };
             logger.debug("request.headers", {
                 headers: logger.sanitizeHeaders(requestHeaders as Record<string, string>),
             });
@@ -403,7 +367,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     ? `${normalizedBaseUrl}/messages`
                     : `${normalizedBaseUrl}/v1/messages`;
                 logger.debug("request.body", { url, requestBody });
-                const response = await executeWithRetry(async () => {
+                const response = await this._sendWithSessionFallback(async () => executeWithRetry(async () => {
                     const res = await dispatchFetch(url, {
                         method: "POST",
                         headers: requestHeaders,
@@ -424,7 +388,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     }
 
                     return res;
-                }, retryConfig);
+                }, retryConfig), rotateSession);
 
                 if (!response.body) {
                     throw new Error("No response body from Anthropic API");
@@ -439,6 +403,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     apiMode: "anthropic",
                     model: model,
                     um: um,
+                    messages: messages,
                     modelApiKey: modelApiKey,
                     baseUrl: BASE_URL,
                     dispatchFetch: dispatchFetch,
@@ -473,7 +438,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
 
                 const url = `${BASE_URL.replace(/\/+$/, "")}/responses`;
                 logger.debug("request.body", { url, requestBody });
-                const response = await executeWithRetry(async () => {
+                const response = await this._sendWithSessionFallback(async () => executeWithRetry(async () => {
                     const res = await dispatchFetch(url, {
                         method: "POST",
                         headers: requestHeaders,
@@ -493,7 +458,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     }
 
                     return res;
-                }, retryConfig);
+                }, retryConfig), rotateSession);
 
                 if (!response.body) {
                     throw new Error("No response body from Responses API");
@@ -506,6 +471,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     apiMode: "openai-responses",
                     model: model,
                     um: um,
+                    messages: messages,
                     modelApiKey: modelApiKey,
                     baseUrl: BASE_URL,
                     dispatchFetch: dispatchFetch,
@@ -545,7 +511,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                 // Send chat request with retry
                 const url = `${BASE_URL.replace(/\/+$/, "")}/chat/completions`;
                 logger.debug("request.body", { url, requestBody });
-                const response = await executeWithRetry(async () => {
+                const response = await this._sendWithSessionFallback(async () => executeWithRetry(async () => {
                     const res = await dispatchFetch(url, {
                         method: "POST",
                         headers: requestHeaders,
@@ -566,7 +532,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     }
 
                     return res;
-                }, retryConfig);
+                }, retryConfig), rotateSession);
 
                 if (!response.body) {
                     throw new Error("No response body from API");
@@ -582,6 +548,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     apiMode: "openai",
                     model: model,
                     um: um,
+                    messages: messages,
                     modelApiKey: modelApiKey,
                     baseUrl: BASE_URL,
                     dispatchFetch: dispatchFetch,
@@ -592,6 +559,15 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     token: token,
                     options: options,
                 });
+            }
+
+            // Persist the session ID for conversations that used a fresh UUID
+            // this turn (first turn, or registry miss after restart): keyed by
+            // model + first user text + this turn's output, which every later
+            // turn re-sends as history. Rotated sessions re-register inside
+            // rotateSessionId() and are skipped here.
+            if (!session.registered) {
+                registerSessionId(model.id, messages, collectedOutputText.join(""), requestHeaders["x-opencode-session"]);
             }
 
             // Fallback: if API did not return usage data, use client-side calculation for native indicator
@@ -685,6 +661,33 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
     }
 
     /**
+     * Send a request, retrying once with a rotated `x-opencode-session` when
+     * the failure is an upstream-provider error: session affinity can pin a
+     * conversation to a broken backend (#123), and a fresh session ID gets
+     * routed elsewhere. The rotated ID is persisted for later turns inside
+     * `rotateSessionId()`.
+     *
+     * @param send Dispatches the request (with its own retry policy); reads
+     *             the request headers at call time so rotation takes effect.
+     * @param rotateSession Replaces the session ID in the shared headers.
+     * @returns The successful response.
+     */
+    private async _sendWithSessionFallback(
+        send: () => Promise<Response>,
+        rotateSession: () => void
+    ): Promise<Response> {
+        try {
+            return await send();
+        } catch (err) {
+            if (!isUpstreamProviderFailureError(err)) {
+                throw err;
+            }
+            rotateSession();
+            return await send();
+        }
+    }
+
+    /**
      * Handle an ask_image tool call interception by calling the vision model
      * with the model's specific query and making a second round API request
      * with the tool call + result. Unlike the old describe_image approach,
@@ -695,6 +698,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
         apiMode: ApiMode;
         model: LanguageModelChatInformation;
         um: OpenCodeGoModelItem | undefined;
+        messages: readonly LanguageModelChatRequestMessage[];
         modelApiKey: string;
         baseUrl: string;
         dispatchFetch: typeof fetch;
@@ -724,6 +728,10 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
             config.get<string>("opencodego.visionProxyModel", "qwen-plus-latest")
         );
         const maxRounds = config.get<number>("opencodego.visionMaxRounds", 5);
+        const rotateSession = (): void => {
+            params.requestHeaders["x-opencode-session"] = rotateSessionId(params.model.id, params.messages);
+            logger.warn("request.sessionRotated", { modelId: params.model.id, visionRound: true });
+        };
 
         // Accumulate messages across rounds
         let currentMessages: any[] = [...storedMessages];
@@ -953,7 +961,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                         ? `${normalizedUrl}/messages`
                         : `${normalizedUrl}/v1/messages`;
 
-                    const response = await executeWithRetry(async () => {
+                    const response = await this._sendWithSessionFallback(async () => executeWithRetry(async () => {
                         const res = await params.dispatchFetch(url, {
                             method: "POST",
                             headers: params.requestHeaders,
@@ -965,7 +973,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                             throw new Error(`Anthropic API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`);
                         }
                         return res;
-                    }, params.retryConfig);
+                    }, params.retryConfig), rotateSession);
 
                     if (response.body) {
                         await api.processStreamingResponse(response.body, params.trackingProgress, params.token);
@@ -996,7 +1004,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     body = responsesApi.prepareRequestBody(body, params.um, params.options);
 
                     const url = `${params.baseUrl.replace(/\/+$/, "")}/responses`;
-                    const response = await executeWithRetry(async () => {
+                    const response = await this._sendWithSessionFallback(async () => executeWithRetry(async () => {
                         const res = await params.dispatchFetch(url, {
                             method: "POST",
                             headers: params.requestHeaders,
@@ -1008,7 +1016,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                             throw new Error(`Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`);
                         }
                         return res;
-                    }, params.retryConfig);
+                    }, params.retryConfig), rotateSession);
 
                     if (response.body) {
                         await responsesApi.processStreamingResponse(response.body, params.trackingProgress, params.token);
@@ -1088,7 +1096,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                     }
 
                     const url = `${params.baseUrl.replace(/\/+$/, "")}/chat/completions`;
-                    const response = await executeWithRetry(async () => {
+                    const response = await this._sendWithSessionFallback(async () => executeWithRetry(async () => {
                         const res = await params.dispatchFetch(url, {
                             method: "POST",
                             headers: params.requestHeaders,
@@ -1100,7 +1108,7 @@ export class OpenCodeGoChatModelProvider implements LanguageModelChatProvider {
                             throw new Error(`API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`);
                         }
                         return res;
-                    }, params.retryConfig);
+                    }, params.retryConfig), rotateSession);
 
                     if (response.body) {
                         await api.processStreamingResponse(response.body, params.trackingProgress, params.token);

--- a/src/sessionRouting.ts
+++ b/src/sessionRouting.ts
@@ -1,6 +1,7 @@
 import * as crypto from "crypto";
 import * as vscode from "vscode";
 import type { LanguageModelChatRequestMessage } from "vscode";
+import { logger } from "./logger";
 
 /**
  * Session ID registry for the `x-opencode-session` header.
@@ -28,13 +29,75 @@ import type { LanguageModelChatRequestMessage } from "vscode";
  * 3. Upstream-provider failures: session affinity can pin a conversation to a
  *    broken backend (#123). `rotateSessionId()` re-registers a fresh UUID so
  *    in-request retries and later turns escape it.
+ *
+ * The registry persists in extension globalState with a sliding 3-day TTL
+ * (entries unused for 3 days expire), so restarting VS Code keeps
+ * conversation affinity.
  */
 
 /** Upper bound on remembered sessions; insertion-order LRU eviction. */
 const MAX_SESSION_ENTRIES = 512;
 
-/** Conversation anchor (sha256 hex) → session ID. */
-const _sessions = new Map<string, string>();
+/** Sessions unused for longer than this are considered expired (sliding TTL). */
+const SESSION_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** globalState key holding the serialized registry across restarts. */
+const STORAGE_KEY = "opencodego.sessionRouting.v1";
+
+/** One remembered conversation: its session ID and when it was last used. */
+interface StoredSessionEntry {
+    sessionId: string;
+    /** Epoch ms of the last resolve/registration, drives the TTL. */
+    lastUsedAt: number;
+}
+
+/** Conversation anchor (sha256 hex) → session entry. */
+const _sessions = new Map<string, StoredSessionEntry>();
+
+/** Persistence backend (extension globalState), set during activation. */
+let _storage: vscode.Memento | undefined;
+
+/**
+ * Restore the registry from extension globalState. Must be called during
+ * activation, before any request can resolve a session ID. Entries unused for
+ * more than the 3-day TTL are dropped on load.
+ *
+ * @param storage The extension's globalState memento.
+ */
+export function initSessionRouting(storage: vscode.Memento): void {
+    _storage = storage;
+    const stored = storage.get<Record<string, StoredSessionEntry>>(STORAGE_KEY, {});
+    const now = Date.now();
+    let restored = 0;
+    let expired = 0;
+    for (const [anchor, entry] of Object.entries(stored ?? {})) {
+        if (!entry || typeof entry.sessionId !== "string" || typeof entry.lastUsedAt !== "number") {
+            continue;
+        }
+        if (now - entry.lastUsedAt > SESSION_TTL_MS) {
+            expired++;
+            continue;
+        }
+        _sessions.set(anchor, entry);
+        restored++;
+    }
+    logger.info("sessionRouting.init", { restored, expired });
+}
+
+/**
+ * Serialize the registry to globalState. Fire-and-forget: a lost write only
+ * costs one registry miss (a fresh UUID) later.
+ */
+function persist(): void {
+    if (!_storage) {
+        return;
+    }
+    const snapshot: Record<string, StoredSessionEntry> = {};
+    for (const [anchor, entry] of _sessions) {
+        snapshot[anchor] = entry;
+    }
+    void Promise.resolve(_storage.update(STORAGE_KEY, snapshot)).catch(() => { });
+}
 
 /** Result of resolving a session ID for an outgoing request. */
 export interface SessionResolution {
@@ -103,12 +166,12 @@ function anchorHash(modelId: string, userText: string, assistantText: string): s
 }
 
 /**
- * Store a session ID under an anchor, refreshing LRU position and evicting
- * the oldest entries beyond the cap.
+ * Store a session ID under an anchor, refreshing LRU position and the TTL
+ * timestamp, evicting the oldest entries beyond the cap, and persisting.
  */
 function store(anchor: string, sessionId: string): void {
     _sessions.delete(anchor);
-    _sessions.set(anchor, sessionId);
+    _sessions.set(anchor, { sessionId, lastUsedAt: Date.now() });
     while (_sessions.size > MAX_SESSION_ENTRIES) {
         const oldest = _sessions.keys().next().value;
         if (oldest === undefined) {
@@ -116,6 +179,7 @@ function store(anchor: string, sessionId: string): void {
         }
         _sessions.delete(oldest);
     }
+    persist();
 }
 
 /**
@@ -143,8 +207,14 @@ export function resolveSessionId(
     const anchor = anchorHash(modelId, userText, assistantText);
     const existing = _sessions.get(anchor);
     if (existing) {
-        store(anchor, existing);
-        return { sessionId: existing, registered: true };
+        if (Date.now() - existing.lastUsedAt > SESSION_TTL_MS) {
+            // Slid past the TTL while the window stayed open — treat as miss.
+            _sessions.delete(anchor);
+            persist();
+            return { sessionId: crypto.randomUUID(), registered: false };
+        }
+        store(anchor, existing.sessionId);
+        return { sessionId: existing.sessionId, registered: true };
     }
     return { sessionId: crypto.randomUUID(), registered: false };
 }
@@ -211,6 +281,7 @@ export function rotateSessionId(
 export function resetSessionRouting(): number {
     const cleared = _sessions.size;
     _sessions.clear();
+    persist();
     return cleared;
 }
 

--- a/src/sessionRouting.ts
+++ b/src/sessionRouting.ts
@@ -1,0 +1,242 @@
+import * as crypto from "crypto";
+import * as vscode from "vscode";
+import type { LanguageModelChatRequestMessage } from "vscode";
+
+/**
+ * Session ID registry for the `x-opencode-session` header.
+ *
+ * OpenCode Go requires a stable per-conversation session ID on every inference
+ * request (server-side session affinity for routing and prompt-cache
+ * optimization) and errors without it since 2026-09-05. VS Code exposes no
+ * conversation identity to language model providers, and the first request of
+ * a conversation contains nothing unique enough to derive a collision-free ID
+ * from. Strategy:
+ *
+ * 1. First turn: send a random UUID. Once the turn completes, register
+ *    `hash(model + first user text + first assistant text) → UUID`. Chat
+ *    clients re-send the full history on every later turn, so the assistant
+ *    output — unique in practice — is part of every subsequent request and
+ *    serves as the registry key. Registration always keys on what the NEXT
+ *    turn's lookup will extract from its re-sent history: the history's first
+ *    assistant message when one exists (registry-miss rebuild after a
+ *    restart or LRU eviction), otherwise this turn's output (which becomes
+ *    that first assistant message next turn).
+ * 2. Later turns: resolve the ID from the registry using the same key
+ *    extracted from the re-sent history. Stable across turns of one
+ *    conversation, distinct across conversations that share an opening
+ *    message.
+ * 3. Upstream-provider failures: session affinity can pin a conversation to a
+ *    broken backend (#123). `rotateSessionId()` re-registers a fresh UUID so
+ *    in-request retries and later turns escape it.
+ */
+
+/** Upper bound on remembered sessions; insertion-order LRU eviction. */
+const MAX_SESSION_ENTRIES = 512;
+
+/** Conversation anchor (sha256 hex) → session ID. */
+const _sessions = new Map<string, string>();
+
+/** Result of resolving a session ID for an outgoing request. */
+export interface SessionResolution {
+    /** The session ID to send. */
+    sessionId: string;
+    /** True when sessionId came from the registry (stable across turns). */
+    registered: boolean;
+}
+
+/**
+ * Concatenate the text content of a message, ignoring binary data parts and
+ * tool call parts so the anchor stays cheap and deterministic.
+ */
+function extractText(content: ReadonlyArray<unknown>): string {
+    let text = "";
+    for (const part of content) {
+        if (typeof part === "string") {
+            text += part;
+        } else if (part instanceof vscode.LanguageModelTextPart) {
+            text += part.value;
+        }
+    }
+    return text;
+}
+
+/**
+ * First non-blank user message text in the history, or null when absent.
+ */
+function firstUserText(messages: readonly LanguageModelChatRequestMessage[]): string | null {
+    for (const message of messages) {
+        if (message.role !== vscode.LanguageModelChatMessageRole.User) {
+            continue;
+        }
+        const text = extractText(message.content);
+        if (text.trim()) {
+            return text;
+        }
+    }
+    return null;
+}
+
+/**
+ * First assistant message text in the re-sent history, or null when the
+ * conversation has no assistant turn yet (first request).
+ */
+function firstAssistantText(messages: readonly LanguageModelChatRequestMessage[]): string | null {
+    for (const message of messages) {
+        if (message.role === vscode.LanguageModelChatMessageRole.Assistant) {
+            return extractText(message.content);
+        }
+    }
+    return null;
+}
+
+/**
+ * Hash the conversation anchor: model ID + first user text + assistant text.
+ */
+function anchorHash(modelId: string, userText: string, assistantText: string): string {
+    const hash = crypto.createHash("sha256");
+    hash.update(modelId);
+    hash.update("\u0000");
+    hash.update(userText);
+    hash.update("\u0000");
+    hash.update(assistantText);
+    return hash.digest("hex");
+}
+
+/**
+ * Store a session ID under an anchor, refreshing LRU position and evicting
+ * the oldest entries beyond the cap.
+ */
+function store(anchor: string, sessionId: string): void {
+    _sessions.delete(anchor);
+    _sessions.set(anchor, sessionId);
+    while (_sessions.size > MAX_SESSION_ENTRIES) {
+        const oldest = _sessions.keys().next().value;
+        if (oldest === undefined) {
+            break;
+        }
+        _sessions.delete(oldest);
+    }
+}
+
+/**
+ * Resolve the session ID for an outgoing chat request. When the re-sent
+ * history already identifies a registered conversation (any turn after the
+ * first), its ID is reused; otherwise a fresh random UUID is returned and the
+ * caller should register it once the turn's assistant output is complete.
+ *
+ * @param modelId The model ID the request targets (keeps sessions distinct per model).
+ * @param messages The request messages from VS Code.
+ * @returns The session ID to send and whether it came from the registry.
+ */
+export function resolveSessionId(
+    modelId: string,
+    messages: readonly LanguageModelChatRequestMessage[]
+): SessionResolution {
+    const userText = firstUserText(messages);
+    if (userText === null) {
+        return { sessionId: crypto.randomUUID(), registered: false };
+    }
+    const assistantText = firstAssistantText(messages);
+    if (assistantText === null) {
+        return { sessionId: crypto.randomUUID(), registered: false };
+    }
+    const anchor = anchorHash(modelId, userText, assistantText);
+    const existing = _sessions.get(anchor);
+    if (existing) {
+        store(anchor, existing);
+        return { sessionId: existing, registered: true };
+    }
+    return { sessionId: crypto.randomUUID(), registered: false };
+}
+
+/**
+ * Register the session ID used by a turn under the anchor that
+ * `resolveSessionId()` will look up on the NEXT turn: `hash(model + first
+ * user text + first assistant text of that turn's re-sent history)`. When
+ * this turn already carries assistant history (registry miss after a restart
+ * or LRU eviction), that first assistant message is in the current history;
+ * on the first turn it is this turn's output, which becomes the first
+ * assistant message next turn.
+ *
+ * @param modelId The model ID the request targeted.
+ * @param messages The request messages from VS Code.
+ * @param turnOutput The assistant output collected during this turn.
+ * @param sessionId The session ID that was sent for this turn.
+ */
+export function registerSessionId(
+    modelId: string,
+    messages: readonly LanguageModelChatRequestMessage[],
+    turnOutput: string,
+    sessionId: string
+): void {
+    const userText = firstUserText(messages);
+    if (userText === null) {
+        return;
+    }
+    const assistantText = firstAssistantText(messages) ?? turnOutput;
+    store(anchorHash(modelId, userText, assistantText), sessionId);
+}
+
+/**
+ * Rotate the session ID after an upstream-provider failure so retries and
+ * later turns are routed away from the broken backend. Re-registers the new
+ * ID when the conversation is already identifiable from the history; on the
+ * first turn (no assistant output yet) the caller's end-of-turn registration
+ * persists the final ID instead.
+ *
+ * @param modelId The model ID the request targets.
+ * @param messages The request messages from VS Code.
+ * @returns A fresh session ID for the retry.
+ */
+export function rotateSessionId(
+    modelId: string,
+    messages: readonly LanguageModelChatRequestMessage[]
+): string {
+    const newId = crypto.randomUUID();
+    const userText = firstUserText(messages);
+    const assistantText = firstAssistantText(messages);
+    if (userText !== null && assistantText !== null) {
+        store(anchorHash(modelId, userText, assistantText), newId);
+    }
+    return newId;
+}
+
+/**
+ * Clear all registered session IDs. The next request of every conversation
+ * gets a fresh UUID — an escape hatch for users pinned to a degraded backend
+ * (#123) without editing their opening message.
+ *
+ * @returns The number of registrations that were cleared.
+ */
+export function resetSessionRouting(): number {
+    const cleared = _sessions.size;
+    _sessions.clear();
+    return cleared;
+}
+
+/**
+ * Detect upstream-provider failures thrown as API errors by the provider
+ * request paths: the observed signature is HTTP 400 with `api_error` /
+ * "Upstream request failed" / "Upstream response was not valid JSON" bodies
+ * (#123), plus any 5xx. Auth (401), rate limits (429) and moderation
+ * rejections never match, so they keep their existing handling.
+ *
+ * @param err The error thrown from a request dispatch.
+ * @returns True when the error is plausibly a broken backend worth a session-ID rotation.
+ */
+export function isUpstreamProviderFailureError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    const statusMatch = message.match(/\[(\d{3})\]/);
+    if (!statusMatch) {
+        return false;
+    }
+    const status = Number(statusMatch[1]);
+    if (status >= 500) {
+        return true;
+    }
+    if (status !== 400) {
+        return false;
+    }
+    const lower = message.toLowerCase();
+    return lower.includes("api_error") && (lower.includes("upstream") || lower.includes("error from provider"));
+}


### PR DESCRIPTION
### Changes

**1. Registry-based per-conversation session IDs (replaces deterministic derivation)**
- The first turn sends a random UUID; once the turn completes, the ID is registered under `hash(model + first user text + first assistant text)`. Later turns re-send the full history, so the same key is extracted from it and the same UUID is reused — stable across turns, and conversations sharing an opening message no longer collide on the derived ID (the assistant output is unique in practice).
- Registration always keys on what the *next* turn's lookup will extract: the history's first assistant message when one exists (registry-miss rebuild after restart or LRU eviction), otherwise this turn's output. Registry misses use a fresh random UUID and re-register at end of turn, so a conversation recovers its affinity after one turn instead of permanently drifting.
- Replaces the `SHA-256(model + first user message)` derivation from #119, which collided across conversations with identical opening messages.

**2. Session-ID rotation fallback for broken backends (#123)**
- Session affinity can pin a conversation to a degraded backend, making every retry fail identically (HTTP 400 `api_error` / "Upstream request failed" / "not valid JSON", or any 5xx). All request dispatches — the three main API modes and every vision-proxy round — are now wrapped in `_sendWithSessionFallback()`: on an upstream-provider failure the session ID is rotated and the request retried once, which re-routes it to a different backend.
- The rotated ID is persisted in the registry, so later turns keep the healthy backend. Auth (401), rate limits (429), and moderation rejections are never treated as upstream failures and keep their existing handling.

**3. Manual escape hatch**
- New `opencodego.resetSessionRouting` command ("Reset Session Routing") clears all registered session IDs so the next request of every conversation starts a fresh session — no more editing the opening message to escape a poisoned route (#123).

Closes #123.

### Files Changed

| File            | Change                                                                                |
| --------------- | ------------------------------------------------------------------------------------- |
| `src/sessionRouting.ts` | New session ID registry: resolve/register/rotate/reset + upstream-failure detection   |
| `src/provider.ts`      | Uses registry IDs, registers after each turn, wraps dispatches with rotation fallback |
| `src/extension.ts`     | Registers the `opencodego.resetSessionRouting` command                                 |
| `package.json` + nls   | Command contribution and en/zh-CN titles                                               |
| `AGENTS.md`            | Documents the `request.sessionRotated` / `sessionRouting.reset` log categories         |
| `docs/`               | reference.md (new section) and architecture.md (flow) synced                           |
